### PR TITLE
refactor: make zod a peer dependency

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -43,7 +43,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
     "enableTopLevelFallback": true,\
     "ignorePatternData": "(^(?:\\\\.yarn\\\\/sdks(?:\\\\/(?!\\\\.{1,2}(?:\\\\/|$))(?:(?:(?!(?:^|\\\\/)\\\\.{1,2}(?:\\\\/|$)).)*?)|$))$)",\
     "fallbackExclusionList": [\
-      ["@targetd/api", ["workspace:packages/api"]],\
+      ["@targetd/api", ["virtual:049c1d28e5b9765667b7008f2694b3886d79f2113b2827f735bfa4f93e239d09c6d92193058dc55e737c58ebb15f0b8530088b5cf795627062174f566080b49f#workspace:packages/api", "workspace:packages/api"]],\
       ["@targetd/client", ["workspace:packages/client"]],\
       ["@targetd/date-range", ["workspace:packages/date-range"]],\
       ["@targetd/fs", ["workspace:packages/fs"]],\
@@ -2768,6 +2768,34 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]\
       ]],\
       ["@targetd/api", [\
+        ["virtual:049c1d28e5b9765667b7008f2694b3886d79f2113b2827f735bfa4f93e239d09c6d92193058dc55e737c58ebb15f0b8530088b5cf795627062174f566080b49f#workspace:packages/api", {\
+          "packageLocation": "./.yarn/__virtual__/@targetd-api-virtual-b466d86b37/1/packages/api/",\
+          "packageDependencies": [\
+            ["@targetd/api", "virtual:049c1d28e5b9765667b7008f2694b3886d79f2113b2827f735bfa4f93e239d09c6d92193058dc55e737c58ebb15f0b8530088b5cf795627062174f566080b49f#workspace:packages/api"],\
+            ["@semantic-release/commit-analyzer", "virtual:93ff9e54e7e85ba03f8777529e2e31fd687b3208f0bfd29f9526626fccebedcf25fd704ae938492bcd5692d38a16927bd020804d445cde5885dc772e9e1e1ff9#npm:9.0.2"],\
+            ["@semantic-release/exec", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:6.0.3"],\
+            ["@semantic-release/git", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:10.0.1"],\
+            ["@semantic-release/github", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:8.0.7"],\
+            ["@semantic-release/release-notes-generator", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:10.0.3"],\
+            ["@types/jest", "npm:29.2.5"],\
+            ["@types/node", "npm:18.11.18"],\
+            ["@types/zod", null],\
+            ["jest", "virtual:78776105526f67704c5d821aa139591fbba11fdbd5f03f51d916c5f752b52ce5b35f9731aa4a7b9fc9fe491d6229cf4b9abfbb54db395f33bbe11c0e0b749fa6#npm:29.3.1"],\
+            ["rimraf", "npm:3.0.2"],\
+            ["semantic-release", "npm:19.0.5"],\
+            ["semantic-release-monorepo", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:7.0.5"],\
+            ["ts-jest", "virtual:78776105526f67704c5d821aa139591fbba11fdbd5f03f51d916c5f752b52ce5b35f9731aa4a7b9fc9fe491d6229cf4b9abfbb54db395f33bbe11c0e0b749fa6#npm:29.0.3"],\
+            ["ts-toolbelt", "npm:9.6.0"],\
+            ["tslib", "npm:2.4.1"],\
+            ["typescript", "patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"],\
+            ["zod", "npm:3.20.2"]\
+          ],\
+          "packagePeers": [\
+            "@types/zod",\
+            "zod"\
+          ],\
+          "linkType": "SOFT"\
+        }],\
         ["workspace:packages/api", {\
           "packageLocation": "./packages/api/",\
           "packageDependencies": [\
@@ -2802,7 +2830,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@semantic-release/git", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:10.0.1"],\
             ["@semantic-release/github", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:8.0.7"],\
             ["@semantic-release/release-notes-generator", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:10.0.3"],\
-            ["@targetd/api", "workspace:packages/api"],\
+            ["@targetd/api", "virtual:049c1d28e5b9765667b7008f2694b3886d79f2113b2827f735bfa4f93e239d09c6d92193058dc55e737c58ebb15f0b8530088b5cf795627062174f566080b49f#workspace:packages/api"],\
             ["@types/jest", "npm:29.2.4"],\
             ["@types/node", "npm:18.11.18"],\
             ["jest", "virtual:78776105526f67704c5d821aa139591fbba11fdbd5f03f51d916c5f752b52ce5b35f9731aa4a7b9fc9fe491d6229cf4b9abfbb54db395f33bbe11c0e0b749fa6#npm:29.3.1"],\
@@ -2812,7 +2840,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["ts-jest", "virtual:049c1d28e5b9765667b7008f2694b3886d79f2113b2827f735bfa4f93e239d09c6d92193058dc55e737c58ebb15f0b8530088b5cf795627062174f566080b49f#npm:29.0.3"],\
             ["ts-toolbelt", "npm:9.6.0"],\
             ["tslib", "npm:2.4.1"],\
-            ["typescript", "patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"]\
+            ["typescript", "patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"],\
+            ["zod", "npm:3.20.2"]\
           ],\
           "linkType": "SOFT"\
         }]\
@@ -2827,7 +2856,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@semantic-release/git", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:10.0.1"],\
             ["@semantic-release/github", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:8.0.7"],\
             ["@semantic-release/release-notes-generator", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:10.0.3"],\
-            ["@targetd/api", "workspace:packages/api"],\
+            ["@targetd/api", "virtual:049c1d28e5b9765667b7008f2694b3886d79f2113b2827f735bfa4f93e239d09c6d92193058dc55e737c58ebb15f0b8530088b5cf795627062174f566080b49f#workspace:packages/api"],\
             ["@types/jest", "npm:29.2.5"],\
             ["@types/node", "npm:18.11.18"],\
             ["jest", "virtual:78776105526f67704c5d821aa139591fbba11fdbd5f03f51d916c5f752b52ce5b35f9731aa4a7b9fc9fe491d6229cf4b9abfbb54db395f33bbe11c0e0b749fa6#npm:29.3.1"],\
@@ -2837,7 +2866,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["semantic-release-monorepo", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:7.0.5"],\
             ["ts-jest", "virtual:78776105526f67704c5d821aa139591fbba11fdbd5f03f51d916c5f752b52ce5b35f9731aa4a7b9fc9fe491d6229cf4b9abfbb54db395f33bbe11c0e0b749fa6#npm:29.0.3"],\
             ["tslib", "npm:2.4.1"],\
-            ["typescript", "patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"]\
+            ["typescript", "patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"],\
+            ["zod", "npm:3.20.2"]\
           ],\
           "linkType": "SOFT"\
         }]\
@@ -2853,7 +2883,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@semantic-release/git", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:10.0.1"],\
             ["@semantic-release/github", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:8.0.7"],\
             ["@semantic-release/release-notes-generator", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:10.0.3"],\
-            ["@targetd/api", "workspace:packages/api"],\
+            ["@targetd/api", "virtual:049c1d28e5b9765667b7008f2694b3886d79f2113b2827f735bfa4f93e239d09c6d92193058dc55e737c58ebb15f0b8530088b5cf795627062174f566080b49f#workspace:packages/api"],\
             ["@types/fs-extra", "npm:9.0.13"],\
             ["@types/jest", "npm:29.2.5"],\
             ["@types/lodash", "npm:4.14.191"],\
@@ -2872,7 +2902,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["tslib", "npm:2.4.1"],\
             ["typescript", "patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"],\
             ["watch", "npm:1.0.2"],\
-            ["yaml", "npm:2.2.1"]\
+            ["yaml", "npm:2.2.1"],\
+            ["zod", "npm:3.20.2"]\
           ],\
           "linkType": "SOFT"\
         }]\
@@ -2948,7 +2979,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@semantic-release/git", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:10.0.1"],\
             ["@semantic-release/github", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:8.0.7"],\
             ["@semantic-release/release-notes-generator", "virtual:8bbf7a23f56d69c61ce3fb6739c3b21bfba2be0c26d1f1893012c8f8e9744fa3cbff3928887945483b9bd6461253526eaee40dc6435a5a7b7e057e35f4df3ae7#npm:10.0.3"],\
-            ["@targetd/api", "workspace:packages/api"],\
+            ["@targetd/api", "virtual:049c1d28e5b9765667b7008f2694b3886d79f2113b2827f735bfa4f93e239d09c6d92193058dc55e737c58ebb15f0b8530088b5cf795627062174f566080b49f#workspace:packages/api"],\
             ["@types/cors", "npm:2.8.13"],\
             ["@types/express", "npm:4.17.15"],\
             ["@types/express-serve-static-core", "npm:4.17.32"],\
@@ -2966,7 +2997,8 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["supertest", "npm:6.3.3"],\
             ["ts-jest", "virtual:78776105526f67704c5d821aa139591fbba11fdbd5f03f51d916c5f752b52ce5b35f9731aa4a7b9fc9fe491d6229cf4b9abfbb54db395f33bbe11c0e0b749fa6#npm:29.0.3"],\
             ["tslib", "npm:2.4.1"],\
-            ["typescript", "patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"]\
+            ["typescript", "patch:typescript@npm%3A4.9.4#~builtin<compat/typescript>::version=4.9.4&hash=ad5954"],\
+            ["zod", "npm:3.20.2"]\
           ],\
           "linkType": "SOFT"\
         }]\

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ data = data.addRules(...)
 All typing and validation is done using the awesome [zod][] project and is exported from the `@targetd/api` package. [Zod][zod] is an easy project to understand and you'll need to know some of the basics.
 
 ```typescript
-import { Data, zod as z } from '@targetd/api'
+import { Data } from '@targetd/api'
+import z from 'zod'
 
 let data = Data.create().useDataValidator(
   'blog',
@@ -95,7 +96,8 @@ data = data.addRules([
 As mentioned above, all typing and validation is done using the [zod][] project.
 
 ```typescript
-import { Data, zod as z } from '@targetd/api'
+import { Data } from '@targetd/api'
+import z from 'zod'
 
 let data = Data.create().useTargeting('category', {
   predicate: (q) => (t) => t.includes(q),

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -27,11 +27,14 @@
     "semantic-release": "19.0.5",
     "semantic-release-monorepo": "7.0.5",
     "ts-jest": "29.0.3",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "zod": "3.20.2"
   },
   "dependencies": {
     "ts-toolbelt": "9.6.0",
-    "tslib": "2.4.1",
-    "zod": "3.20.2"
+    "tslib": "2.4.1"
+  },
+  "peerDependencies": {
+    "zod": "^3.20.0"
   }
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -6,4 +6,3 @@ export { default as createTargetingDescriptor } from './createTargetingDescripto
 export { default as TargetingDescriptor } from './validators/TargetingDescriptor'
 export { default as TargetingPredicate } from './validators/TargetingPredicate'
 export { default as TargetingPredicates } from './validators/TargetingPredicates'
-export { default as zod } from 'zod'

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -7,8 +7,9 @@ Sometimes you can't rely on one data service to fulfil all the target filtering.
 ## Example
 
 ```typescript
-import { Data, zod as z } from '@targetd/api'
+import { Data } from '@targetd/api'
 import { ClientData } from '@targetd/client'
+import z from 'zod'
 
 const Device = z.literal('desktop').or(z.literal('mobile'))
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -29,13 +29,15 @@
     "semantic-release": "19.0.5",
     "semantic-release-monorepo": "7.0.5",
     "ts-jest": "29.0.3",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "zod": "3.20.2"
   },
   "dependencies": {
     "ts-toolbelt": "9.6.0",
     "tslib": "2.4.1"
   },
   "peerDependencies": {
-    "@targetd/api": ">=3.0.0"
+    "@targetd/api": ">=3.0.0",
+    "zod": "^3.20.0"
   }
 }

--- a/packages/client/src/ClientData.ts
+++ b/packages/client/src/ClientData.ts
@@ -1,8 +1,9 @@
-import { Data, zod as z } from '@targetd/api'
+import { Data } from '@targetd/api'
 import { StaticRecord } from '@targetd/api/dist/types'
-import { Keys } from 'ts-toolbelt/out/Any/Keys'
-import { ServedData } from './ServedData'
 import { RuleWithPayload } from '@targetd/api/dist/validators/DataItemRule'
+import { Keys } from 'ts-toolbelt/out/Any/Keys'
+import z from 'zod'
+import { ServedData } from './ServedData'
 
 export class ClientData<
   DataValidators extends z.ZodRawShape,

--- a/packages/client/src/ServedData.ts
+++ b/packages/client/src/ServedData.ts
@@ -1,4 +1,4 @@
-import { zod as z } from '@targetd/api'
+import z from 'zod'
 import { RuleWithPayload } from '@targetd/api/dist/validators/DataItemRule'
 
 export type ServedData<

--- a/packages/client/test/ClientData.test.ts
+++ b/packages/client/test/ClientData.test.ts
@@ -1,4 +1,5 @@
-import { Data, zod as z } from '@targetd/api'
+import { Data } from '@targetd/api'
+import z from 'zod'
 import { ClientData } from '../src'
 
 const data = Data.create()

--- a/packages/date-range/README.md
+++ b/packages/date-range/README.md
@@ -5,8 +5,9 @@
 ## Example
 
 ```typescript
-import { Data, zod as z } from '@targetd/api'
+import { Data } from '@targetd/api'
 import dateRangeTargeting from '@targetd/date-range'
+import z from 'zod'
 
 const data = Data.create()
   .useTargeting('dateRange', dateRangeTargeting)

--- a/packages/date-range/package.json
+++ b/packages/date-range/package.json
@@ -29,12 +29,14 @@
     "semantic-release": "19.0.5",
     "semantic-release-monorepo": "7.0.5",
     "ts-jest": "29.0.3",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "zod": "3.20.2"
   },
   "dependencies": {
     "tslib": "2.4.1"
   },
   "peerDependencies": {
-    "@targetd/api": ">=3.0.0"
+    "@targetd/api": ">=3.0.0",
+    "zod": "^3.20.0"
   }
 }

--- a/packages/date-range/src/index.ts
+++ b/packages/date-range/src/index.ts
@@ -1,4 +1,5 @@
-import { createTargetingDescriptor, zod as z } from '@targetd/api'
+import { createTargetingDescriptor } from '@targetd/api'
+import z from 'zod'
 
 const ISODateTime = z
   .string()

--- a/packages/date-range/test/index.test.ts
+++ b/packages/date-range/test/index.test.ts
@@ -1,5 +1,6 @@
-import { Data, zod as z } from '@targetd/api'
+import { Data } from '@targetd/api'
 import * as jestDate from 'jest-date-mock'
+import z from 'zod'
 import dateRangeTargeting from '../src'
 
 test('date range predicate', async () => {

--- a/packages/fs/README.md
+++ b/packages/fs/README.md
@@ -22,16 +22,17 @@ b:
 ```
 
 ```typescript
-import { Data, zod as z } from '@targetd/api'
+import { Data } from '@targetd/api'
 import { watch } from '@targetd/fs'
 import * as path from 'node:path'
+import z from 'zod'
 
 watch(
   Data.create()
     .useDataValidator('foo', z.string())
     .useDataValidator('b', z.string()),
 
-  path.join(__dirname, 'data'),
+  path.join(__dirname, 'rules'),
 
   async (data) => {
     expect(await data.getPayload('foo', {})).toBe('bar')

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -34,7 +34,8 @@
     "semantic-release-monorepo": "7.0.5",
     "ts-jest": "29.0.3",
     "ts-node": "10.9.1",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "zod": "3.20.2"
   },
   "dependencies": {
     "@johngw/fs": "2.0.1",
@@ -46,6 +47,7 @@
     "yaml": "2.2.1"
   },
   "peerDependencies": {
-    "@targetd/api": ">=3.1.0"
+    "@targetd/api": ">=3.1.0",
+    "zod": "^3.20.0"
   }
 }

--- a/packages/fs/src/load.ts
+++ b/packages/fs/src/load.ts
@@ -1,7 +1,8 @@
 import { readFiles } from '@johngw/fs'
 import { WithFileNamesResult } from '@johngw/fs/dist/readFiles'
+import { Data } from '@targetd/api'
 import YAML from 'yaml'
-import { Data, zod as z } from '@targetd/api'
+import z from 'zod'
 
 const FileData = z.record(z.string(), z.array(z.unknown()))
 type FileData = z.infer<typeof FileData>

--- a/packages/fs/src/watch.ts
+++ b/packages/fs/src/watch.ts
@@ -1,6 +1,7 @@
-import { Data, zod as z } from '@targetd/api'
+import { Data } from '@targetd/api'
 import { debounce } from 'lodash'
 import { Options as WatchTreeOptions, unwatchTree, watchTree } from 'watch'
+import z from 'zod'
 import { load, pathIsLoadable } from './load'
 
 export type OnLoad<

--- a/packages/fs/test/load.test.ts
+++ b/packages/fs/test/load.test.ts
@@ -1,6 +1,7 @@
+import { Data } from '@targetd/api'
+import * as path from 'node:path'
+import z from 'zod'
 import { load } from '../src'
-import * as path from 'path'
-import { Data, zod as z } from '@targetd/api'
 
 test('load', async () => {
   const data = await load(

--- a/packages/fs/test/watch.test.ts
+++ b/packages/fs/test/watch.test.ts
@@ -1,6 +1,7 @@
-import { Data, zod as z } from '@targetd/api'
-import * as path from 'node:path'
+import { Data } from '@targetd/api'
 import { emptyDir, copy } from 'fs-extra'
+import * as path from 'node:path'
+import z from 'zod'
 import { watch } from '../src'
 
 let stopWatching: undefined | (() => void)

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -5,8 +5,9 @@
 ## Exammple
 
 ```typescript
-import { Data, zod as z } from '@targetd/api',
+import { Data } from '@targetd/api',
 import { createServer } from '@targetd/server'
+import z from 'zod'
 
 const data = Data.create()
   .useDataValidator('foo', z.string())

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,7 +32,8 @@
     "semantic-release-monorepo": "7.0.5",
     "supertest": "6.3.3",
     "ts-jest": "29.0.3",
-    "typescript": "4.9.4"
+    "typescript": "4.9.4",
+    "zod": "3.20.2"
   },
   "dependencies": {
     "@johngw/error": "2.2.0",
@@ -46,6 +47,7 @@
     "tslib": "2.4.1"
   },
   "peerDependencies": {
-    "@targetd/api": ">=3.0.0"
+    "@targetd/api": ">=3.0.0",
+    "zod": "^3.20.0"
   }
 }

--- a/packages/server/src/middleware/error.ts
+++ b/packages/server/src/middleware/error.ts
@@ -1,5 +1,5 @@
-import { zod as z } from '@targetd/api'
 import express from 'express'
+import z from 'zod'
 
 export function errorHandler(): express.ErrorRequestHandler {
   return (err, _req, res, next) => {

--- a/packages/server/test/index.test.ts
+++ b/packages/server/test/index.test.ts
@@ -1,8 +1,9 @@
-import { Data, zod as z } from '@targetd/api'
+import { Data } from '@targetd/api'
 import express from 'express'
 import { promisify } from 'node:util'
 import { setTimeout } from 'node:timers'
 import request from 'supertest'
+import z from 'zod'
 import { createServer } from '../src'
 
 const timeout = promisify(setTimeout)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2063,6 +2063,8 @@ __metadata:
     tslib: 2.4.1
     typescript: 4.9.4
     zod: 3.20.2
+  peerDependencies:
+    zod: ^3.20.0
   languageName: unknown
   linkType: soft
 
@@ -2086,8 +2088,10 @@ __metadata:
     ts-toolbelt: 9.6.0
     tslib: 2.4.1
     typescript: 4.9.4
+    zod: 3.20.2
   peerDependencies:
     "@targetd/api": ">=3.0.0"
+    zod: ^3.20.0
   languageName: unknown
   linkType: soft
 
@@ -2111,8 +2115,10 @@ __metadata:
     ts-jest: 29.0.3
     tslib: 2.4.1
     typescript: 4.9.4
+    zod: 3.20.2
   peerDependencies:
     "@targetd/api": ">=3.0.0"
+    zod: ^3.20.0
   languageName: unknown
   linkType: soft
 
@@ -2146,8 +2152,10 @@ __metadata:
     typescript: 4.9.4
     watch: 1.0.2
     yaml: 2.2.1
+    zod: 3.20.2
   peerDependencies:
-    "@targetd/api": ">=3.0.0"
+    "@targetd/api": ">=3.1.0"
+    zod: ^3.20.0
   languageName: unknown
   linkType: soft
 
@@ -2236,8 +2244,10 @@ __metadata:
     ts-jest: 29.0.3
     tslib: 2.4.1
     typescript: 4.9.4
+    zod: 3.20.2
   peerDependencies:
     "@targetd/api": ">=3.0.0"
+    zod: ^3.20.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
BREAKING CHANGE: targetd no longer provides a version of zod, you must install it yourself.