### PR TITLE
feat: ensure no extra properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ import { Data, zod as z } from '@targetd/api'
 
 let data = Data.create().useDataValidator(
   'blog',
-  z.object({
+  z.strictObject({
     title: z.string(),
     body: z.string(),
   })

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -6,6 +6,12 @@ export type StaticRecord<R extends z.ZodRawShape> = {
 
 export type MaybePromise<T> = T | Promise<T>
 
-export type ZodPartialObject<T extends z.ZodRawShape> = z.ZodObject<{
-  [K in keyof T]: z.ZodOptional<T[K]>
-}>
+export type ZodPartialObject<
+  T extends z.ZodRawShape,
+  UnknownKeys extends z.UnknownKeysParam = 'strip'
+> = z.ZodObject<
+  {
+    [K in keyof T]: z.ZodOptional<T[K]>
+  },
+  UnknownKeys
+>

--- a/packages/api/src/validators/DataItem.ts
+++ b/packages/api/src/validators/DataItem.ts
@@ -5,7 +5,7 @@ function DataItem<P extends z.ZodTypeAny, T extends z.ZodRawShape>(
   Payload: P,
   targeting: T
 ): DataItem<P, T> {
-  return z.object({
+  return z.strictObject({
     rules: z.array(DataItemRule(Payload, targeting)),
   })
 }
@@ -13,8 +13,11 @@ function DataItem<P extends z.ZodTypeAny, T extends z.ZodRawShape>(
 type DataItem<
   Payload extends z.ZodTypeAny,
   Targeting extends z.ZodRawShape
-> = z.ZodObject<{
-  rules: z.ZodArray<DataItemRule<Payload, Targeting>>
-}>
+> = z.ZodObject<
+  {
+    rules: z.ZodArray<DataItemRule<Payload, Targeting>>
+  },
+  'strict'
+>
 
 export default DataItem

--- a/packages/api/src/validators/DataItemRule.ts
+++ b/packages/api/src/validators/DataItemRule.ts
@@ -5,14 +5,14 @@ function DataItemRule<P extends z.ZodTypeAny, T extends z.ZodRawShape>(
   Payload: P,
   targeting: T
 ): DataItemRule<P, T> {
-  const Targeting = z.object(targeting).partial().optional()
+  const Targeting = z.strictObject(targeting).partial().optional()
 
-  const RuleWithPayload = z.object({
+  const RuleWithPayload = z.strictObject({
     targeting: Targeting,
     payload: Payload,
   })
 
-  const ClientDataItemRule = z.object({
+  const ClientDataItemRule = z.strictObject({
     targeting: Targeting,
     client: z.array(RuleWithPayload),
   })
@@ -26,10 +26,13 @@ type DataItemRule<
 > = z.ZodUnion<
   [
     RuleWithPayload<Payload, Targeting>,
-    z.ZodObject<{
-      targeting: z.ZodOptional<ZodPartialObject<Targeting>>
-      client: z.ZodArray<RuleWithPayload<Payload, Targeting>>
-    }>
+    z.ZodObject<
+      {
+        targeting: z.ZodOptional<ZodPartialObject<Targeting, 'strict'>>
+        client: z.ZodArray<RuleWithPayload<Payload, Targeting>>
+      },
+      'strict'
+    >
   ]
 >
 
@@ -38,7 +41,10 @@ export default DataItemRule
 export type RuleWithPayload<
   Payload extends z.ZodTypeAny,
   Targeting extends z.ZodRawShape
-> = z.ZodObject<{
-  targeting: z.ZodOptional<ZodPartialObject<Targeting>>
-  payload: Payload
-}>
+> = z.ZodObject<
+  {
+    targeting: z.ZodOptional<ZodPartialObject<Targeting, 'strict'>>
+    payload: Payload
+  },
+  'strict'
+>

--- a/packages/api/src/validators/DataItems.ts
+++ b/packages/api/src/validators/DataItems.ts
@@ -10,14 +10,17 @@ function DataItems<D extends z.ZodRawShape, T extends z.ZodRawShape>(
   for (const [key, Payload] of Object.entries(dataValidators)) {
     dataItems[key] = DataItem(Payload, targeting)
   }
-  return z.object(dataItems).partial() as DataItems<D, T>
+  return z.strictObject(dataItems).partial() as DataItems<D, T>
 }
 
 type DataItems<
   DataTypes extends z.ZodRawShape,
   Targeting extends z.ZodRawShape
-> = ZodPartialObject<{
-  [Name in keyof DataTypes]: DataItem<DataTypes[Name], Targeting>
-}>
+> = ZodPartialObject<
+  {
+    [Name in keyof DataTypes]: DataItem<DataTypes[Name], Targeting>
+  },
+  'strict'
+>
 
 export default DataItems

--- a/packages/api/test/Data.test.ts
+++ b/packages/api/test/Data.test.ts
@@ -57,13 +57,6 @@ test('getPayload', async () => {
       {
         payload: 'bar',
       },
-      {
-        targeting: {
-          // @ts-expect-error
-          nonExistantKey: 'some value',
-        },
-        payload: 'error',
-      },
     ])
 
   expect(await data.getPayload('foo', {})).toBe('bar')
@@ -76,10 +69,26 @@ test('getPayload', async () => {
   expect(await data.getPayload('foo', { asyncThing: true })).toBe(
     'Async payload'
   )
+
   // @ts-expect-error
   await data.getPayload('mung', {})
-  // @ts-expect-error
-  await data.getPayload('foo', { nonExistantKey: 'some value' })
+
+  expect(
+    // @ts-expect-error
+    data.getPayload('foo', { nonExistantKey: 'some value' })
+  ).rejects.toThrow()
+
+  expect(() =>
+    data.addRules('foo', [
+      {
+        targeting: {
+          // @ts-expect-error
+          nonExistantKey: 'some value',
+        },
+        payload: 'error',
+      },
+    ])
+  ).toThrow()
 })
 
 test('targeting without requiring a query', async () => {


### PR DESCRIPTION
Make sure that rule formats are strict.

BREAKING CHANGE: queries containing extra properties will fail