### PR TITLE
refactor(api): collapse DataSchema builder/built distinction and remove DT.Meta

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,14 +37,15 @@ and built-in predicates in
 
 **Two-phase API**: Schema setup uses
 [DataSchema](packages/api/src/DataSchema.ts) (synchronous, accumulates parser
-shapes via intersection for cheap type inference). `.build()` produces a
-`BuiltDataSchema<Meta>`, which `Data.create(schema)` turns into a
+shapes via intersection for cheap type inference). The resulting `DataSchema` is
+passed directly to `Data.create(schema)`, which returns a
 [PromisedData](packages/api/src/PromisedData.ts) — an awaitable chain for
 `addRules`/`insert`/query operations.
 
-**Type Inference**: Heavy use of TypeScript's type system with Zod schemas. The
-`Data` class uses complex type inference (`DT.Meta`) to ensure payloads,
-targeting, and queries are type-safe across the API.
+**Type Inference**: Heavy use of TypeScript's type system with Zod schemas.
+`Data<$ extends DataSchema = DataSchema>` carries the schema's concrete parser
+shapes so payloads, targeting, and queries stay type-safe across the API. Access
+the schema types via indexed access on the generic, e.g. `$['payloadParsers']`.
 
 ### Creating Custom Targeting Descriptors
 
@@ -196,16 +197,14 @@ challenging:
 const data = await Data.create(
   DataSchema.create()
     .usePayload({ foo: z.string() })
-    .useTargeting({ bar: targetIncludes(z.string()) })
-    .build(),
+    .useTargeting({ bar: targetIncludes(z.string()) }),
 ).addRules('foo', rules)
 
 // Break it down to inspect types
 const step1 = DataSchema.create()
 const step2 = step1.usePayload({ foo: z.string() })
 const step3 = step2.useTargeting({ bar: targetIncludes(z.string()) })
-const built = step3.build()
-type BuiltType = typeof built // Inspect in IDE
+type SchemaType = typeof step3 // Inspect in IDE
 ```
 
 **Strategy 2: Use helper types from `types/` directories**

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ import { z } from 'zod'
 const schema = DataSchema.create()
   .usePayload({ greeting: z.string() })
   .useTargeting({ country: targetIncludes(z.string()) })
-  .build()
 
 const data = await Data.create(schema).addRules('greeting', [
   { targeting: { country: ['US'] }, payload: 'Hello!' },
@@ -98,7 +97,6 @@ import dateRangeTargeting from '@targetd/date-range'
 const schema = DataSchema.create()
   .usePayload({ campaign: z.string() })
   .useTargeting({ date: dateRangeTargeting })
-  .build()
 
 const data = await Data.create(schema).addRules('campaign', [
   {
@@ -164,7 +162,6 @@ const schema = DataSchema.create()
     platform: targetIncludes(z.string()),
     isPremium: targetIncludes(z.boolean()),
   })
-  .build()
 
 export const data = await Data.create(schema)
   .addRules('banner', [
@@ -211,8 +208,7 @@ const allPayloads = await client.getPayloadForEachName({ isPremium: true })
 const data = await Data.create(
   DataSchema.create()
     .usePayload({ newFeature: z.boolean() })
-    .useTargeting({ userTier: targetEquals(z.string()) })
-    .build(),
+    .useTargeting({ userTier: targetEquals(z.string()) }),
 ).addRules('newFeature', [
   { targeting: { userTier: 'beta' }, payload: true },
   { payload: false },
@@ -225,8 +221,7 @@ const data = await Data.create(
 const data = await Data.create(
   DataSchema.create()
     .usePayload({ variant: z.string() })
-    .useTargeting({ userId: targetIncludes(z.string()) })
-    .build(),
+    .useTargeting({ userId: targetIncludes(z.string()) }),
 ).addRules('variant', [
   { targeting: { userId: experimentGroup }, payload: 'variant-a' },
   { payload: 'variant-b' },
@@ -242,8 +237,7 @@ const data = await Data.create(
     .useTargeting({
       region: targetIncludes(z.string()),
       language: targetIncludes(z.string()),
-    })
-    .build(),
+    }),
 ).addRules('content', [
   {
     targeting: { region: ['US'], language: ['en'] },
@@ -268,8 +262,7 @@ const data = await Data.create(
         timeout: z.number(),
       }),
     })
-    .useTargeting({ environment: targetEquals(z.string()) })
-    .build(),
+    .useTargeting({ environment: targetEquals(z.string()) }),
 ).addRules('config', [
   {
     targeting: { environment: 'production' },
@@ -287,8 +280,8 @@ const data = await Data.create(
 
 ### Schema Configuration
 
-Use `DataSchema` to declare payload schemas and targeting descriptors, then
-`.build()` and pass the result to `Data.create()`. Splitting the schema and data
+Use `DataSchema` to declare payload schemas and targeting descriptors, then pass
+the resulting schema directly to `Data.create()`. Splitting the schema and data
 phases keeps TypeScript compilation cheap even with hundreds of payloads and
 targeting descriptors.
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -25,8 +25,8 @@ for serving different payloads based on targeting conditions. It's ideal for:
 
 ### Creating a Data Store
 
-Configure payload and targeting schemas with `DataSchema`, then pass the built
-config to `Data.create()`:
+Configure payload and targeting schemas with `DataSchema`, then pass the schema
+directly to `Data.create()`:
 
 ```typescript
 import { Data, DataSchema, targetEquals, targetIncludes } from '@targetd/api'
@@ -39,7 +39,6 @@ const schema = DataSchema.create()
   .useTargeting({
     country: targetIncludes(z.string()),
   })
-  .build()
 
 const data = await Data.create(schema).addRules('greeting', [
   {
@@ -64,9 +63,9 @@ const defaultGreeting = await data.getPayload('greeting')
 ```
 
 Schema configuration (`DataSchema`) and data operations (`Data`) are split so
-that TypeScript only has to resolve the accumulated parser types once, at
-`.build()`. This keeps compilation cheap even when hundreds of payloads and
-targeting descriptors are chained together.
+that TypeScript only has to resolve the accumulated parser types on the schema,
+then reuse that single type inside `Data.create()`. This keeps compilation cheap
+even when hundreds of payloads and targeting descriptors are chained together.
 
 ## Core Concepts
 
@@ -84,7 +83,6 @@ const schema = DataSchema.create()
       maxRetries: z.number(),
     }),
   })
-  .build()
 ```
 
 ### 2. Targeting
@@ -99,7 +97,6 @@ built-in predicates or create custom ones:
   const schema = DataSchema.create()
     .usePayload({ content: z.string() })
     .useTargeting({ channels: targetIncludes(z.string()) })
-    .build()
 
   const data = await Data.create(schema).addRules('content', [
     {
@@ -114,7 +111,6 @@ built-in predicates or create custom ones:
   const schema = DataSchema.create()
     .usePayload({ feature: z.string() })
     .useTargeting({ isPremium: targetEquals(z.boolean()) })
-    .build()
 
   const data = await Data.create(schema).addRules('feature', [
     {
@@ -140,7 +136,6 @@ const schema = DataSchema.create()
       targetingParser: z.enum(['morning', 'afternoon', 'evening']),
     },
   })
-  .build()
 
 const data = await Data.create(schema).addRules('message', [
   {
@@ -300,7 +295,6 @@ const schema = DataSchema.create()
   .useFallThroughTargeting({
     region: z.array(z.string()),
   })
-  .build()
 
 const data = await Data.create(schema).addRules('message', [
   {
@@ -335,7 +329,6 @@ const receivingConfig = DataSchema.create()
   .useTargeting({
     region: targetIncludes(z.string()),
   })
-  .build()
 
 const receivingServiceData = await Data.create(receivingConfig).insert({
   message: result, // The __rules__ structure from the first service
@@ -407,7 +400,6 @@ const schema = DataSchema.create()
   .useTargeting({
     platform: targetIncludes(z.string(), { withNegate: true }),
   })
-  .build()
 
 const data = await Data.create(schema).addRules('content', [
   {
@@ -430,7 +422,6 @@ const schema = DataSchema.create()
     tide: targetEquals(z.boolean()),
     wind: targetEquals(z.string()),
   })
-  .build()
 
 const data = await Data.create(schema).addRules('experience', [
   {
@@ -462,7 +453,6 @@ The library provides full TypeScript type inference:
 const schema = DataSchema.create()
   .usePayload({ message: z.string() })
   .useTargeting({ country: targetIncludes(z.string()) })
-  .build()
 
 const data = await Data.create(schema)
 

--- a/packages/api/src/Data.ts
+++ b/packages/api/src/Data.ts
@@ -1,4 +1,3 @@
-import type TargetingPredicates from './parsers/TargetingPredicates.ts'
 import {
   objectEntries,
   objectEveryAsync,
@@ -28,11 +27,11 @@ import { PromisedData } from './PromisedData.ts'
 import { resolveVariables } from './parsers/DataItemVariableResolver.ts'
 import type { InsertableData } from './InsertableData.ts'
 import type { QueryableData } from './QueryableData.ts'
-import type { BuiltDataSchema } from './DataSchema.ts'
+import type { DataSchema } from './DataSchema.ts'
 
 /**
  * In-memory data store. Configure payload and targeting schemas with
- * {@link DataSchema}, then pass the built schema to {@link Data.create}.
+ * {@link DataSchema}, then pass the schema to {@link Data.create}.
  *
  * @example
  * ```ts
@@ -43,7 +42,6 @@ import type { BuiltDataSchema } from './DataSchema.ts'
  * const schema = DataSchema.create()
  *   .usePayload({ foo: z.string() })
  *   .useTargeting({ channel: targetIncludes(z.string()) })
- *   .build()
  *
  * const data = await Data.create(schema).addRules('foo', [
  *   {
@@ -61,20 +59,16 @@ import type { BuiltDataSchema } from './DataSchema.ts'
  * )
  * ```
  */
-export default class Data<$ extends DT.Meta>
+export default class Data<$ extends DataSchema = DataSchema>
   implements InsertableData<$>, QueryableData<$> {
-  readonly #fallThroughTargetingParsers: $['FallThroughTargetingParsers']
+  readonly #schema: $
   readonly #data: DataItemsOut<$>
-  readonly #payloadParsers: $['PayloadParsers']
-  readonly #targetingPredicates: TargetingPredicates<$>
-  readonly #targetingParsers: $['TargetingParsers']
-  readonly #queryParsers: $['QueryParsers']
-  readonly #QueryParser: ZodPartialObject<$['QueryParsers']>
+  readonly #QueryParser: ZodPartialObject<$['queryParsers']>
 
   /**
-   * Create a new empty Data instance from a {@link BuiltDataSchema}.
+   * Create a new empty Data instance from a {@link DataSchema}.
    *
-   * @param schema - A schema produced by {@link DataSchema.build}.
+   * @param schema - A schema produced by chaining {@link DataSchema.create} and `use*` calls.
    * @returns A PromisedData instance ready for rules, inserts, and queries.
    *
    * @example
@@ -84,25 +78,17 @@ export default class Data<$ extends DT.Meta>
    *
    * const schema = DataSchema.create()
    *   .usePayload({ greeting: z.string() })
-   *   .build()
    *
    * const data = await Data.create(schema).addRules('greeting', [
    *   { payload: 'Hello!' },
    * ])
    * ```
    */
-  static create<$ extends DT.Meta>(
-    schema: BuiltDataSchema<$>,
+  static create<$ extends DataSchema>(
+    schema: $,
   ): PromisedData<$> {
     return PromisedData.create(
-      new Data<$>(
-        {} as DataItemsOut<$>,
-        schema.payloadParsers,
-        schema.targetingPredicates,
-        schema.targetingParsers,
-        schema.queryParsers,
-        schema.fallThroughTargetingParsers,
-      ),
+      new Data<$>(schema, {} as DataItemsOut<$>),
     )
   }
 
@@ -110,22 +96,21 @@ export default class Data<$ extends DT.Meta>
    * @see {@link Data.create}
    */
   private constructor(
+    schema: $,
     data: DataItemsOut<$>,
-    payloadParsers: $['PayloadParsers'],
-    targetingPredicates: TargetingPredicates<$>,
-    targetingParsers: $['TargetingParsers'],
-    queryParsers: $['QueryParsers'],
-    fallThroughTargetingParsers: $['FallThroughTargetingParsers'],
   ) {
-    this.#fallThroughTargetingParsers = Object.freeze(
-      fallThroughTargetingParsers,
-    )
+    this.#schema = schema
     this.#data = Object.freeze(data)
-    this.#payloadParsers = Object.freeze(payloadParsers)
-    this.#targetingPredicates = Object.freeze(targetingPredicates)
-    this.#targetingParsers = Object.freeze(targetingParsers)
-    this.#queryParsers = Object.freeze(queryParsers)
-    this.#QueryParser = partial(strictObject(this.#queryParsers))
+    this.#QueryParser = partial(
+      strictObject(schema.queryParsers),
+    ) as ZodPartialObject<$['queryParsers']>
+  }
+
+  /**
+   * Get the schema used to configure this Data instance.
+   */
+  get schema(): $ {
+    return this.#schema
   }
 
   /**
@@ -142,8 +127,8 @@ export default class Data<$ extends DT.Meta>
    *
    * @returns Object mapping payload names to their Zod schemas.
    */
-  get payloadParsers(): $['PayloadParsers'] {
-    return this.#payloadParsers
+  get payloadParsers(): $['payloadParsers'] {
+    return this.#schema.payloadParsers
   }
 
   /**
@@ -151,8 +136,8 @@ export default class Data<$ extends DT.Meta>
    *
    * @returns Object mapping targeting keys to their predicate functions and configuration.
    */
-  get targetingPredicates(): TargetingPredicates<$> {
-    return this.#targetingPredicates
+  get targetingPredicates(): $['targetingPredicates'] {
+    return this.#schema.targetingPredicates
   }
 
   /**
@@ -160,8 +145,8 @@ export default class Data<$ extends DT.Meta>
    *
    * @returns Object mapping targeting keys to their Zod schemas.
    */
-  get targetingParsers(): $['TargetingParsers'] {
-    return this.#targetingParsers
+  get targetingParsers(): $['targetingParsers'] {
+    return this.#schema.targetingParsers
   }
 
   /**
@@ -169,8 +154,8 @@ export default class Data<$ extends DT.Meta>
    *
    * @returns Object mapping query parameter names to their Zod schemas.
    */
-  get queryParsers(): $['QueryParsers'] {
-    return this.#queryParsers
+  get queryParsers(): $['queryParsers'] {
+    return this.#schema.queryParsers
   }
 
   /**
@@ -178,7 +163,7 @@ export default class Data<$ extends DT.Meta>
    *
    * @returns Zod schema that validates query objects.
    */
-  get QueryParser(): ZodPartialObject<$['QueryParsers'], $strict> {
+  get QueryParser(): ZodPartialObject<$['queryParsers'], $strict> {
     return this.#QueryParser
   }
 
@@ -187,8 +172,8 @@ export default class Data<$ extends DT.Meta>
    *
    * @returns Object mapping fall-through targeting keys to their Zod schemas.
    */
-  get fallThroughTargetingParsers(): $['FallThroughTargetingParsers'] {
-    return this.#fallThroughTargetingParsers
+  get fallThroughTargetingParsers(): $['fallThroughTargetingParsers'] {
+    return this.#schema.fallThroughTargetingParsers
   }
 
   /**
@@ -212,9 +197,9 @@ export default class Data<$ extends DT.Meta>
     const newData = {
       ...this.#data,
       ...(await DataItemsParser(
-        this.#payloadParsers,
-        this.#targetingParsers,
-        this.#fallThroughTargetingParsers,
+        this.#schema.payloadParsers,
+        this.#schema.targetingParsers,
+        this.#schema.fallThroughTargetingParsers,
         false,
       ).parseAsync(
         Object.entries(data).reduce((data, [name, value]) => {
@@ -245,21 +230,14 @@ export default class Data<$ extends DT.Meta>
       )),
     }
 
-    return new Data(
-      newData,
-      this.#payloadParsers,
-      this.#targetingPredicates,
-      this.#targetingParsers,
-      this.#queryParsers,
-      this.#fallThroughTargetingParsers,
-    )
+    return new Data(this.#schema, newData)
   }
 
   readonly #isFallThroughRulesPayload = <
-    Name extends keyof $['PayloadParsers'],
+    Name extends keyof $['payloadParsers'],
   >(
-    payload: PT.Payload<$, $['PayloadParsers'][Name]>,
-  ): payload is FTTT.Rules<$, $['PayloadParsers'][Name]> =>
+    payload: PT.Payload<$, $['payloadParsers'][Name]>,
+  ): payload is FTTT.Rules<$, $['payloadParsers'][Name]> =>
     typeof payload === 'object' && payload !== null && '__rules__' in payload
 
   /**
@@ -274,8 +252,7 @@ export default class Data<$ extends DT.Meta>
    * const data = await Data.create(
    *   DataSchema.create()
    *     .usePayload({ greeting: z.string() })
-   *     .useTargeting({ country: targetIncludes(z.string()) })
-   *     .build(),
+   *     .useTargeting({ country: targetIncludes(z.string()) }),
    * ).addRules('greeting', [
    *   { targeting: { country: ['US'] }, payload: 'Hello!' },
    *   { targeting: { country: ['ES'] }, payload: '¡Hola!' },
@@ -299,12 +276,12 @@ export default class Data<$ extends DT.Meta>
    * ```
    */
   async addRules<
-    Name extends keyof $['PayloadParsers'],
+    Name extends keyof $['payloadParsers'],
   >(
     name: Name,
     opts:
-      | DataItemIn<$, $['PayloadParsers'][Name]>
-      | DataItemRulesIn<$, $['PayloadParsers'][Name]>,
+      | DataItemIn<$, $['payloadParsers'][Name]>
+      | DataItemRulesIn<$, $['payloadParsers'][Name]>,
   ): Promise<Data<$>> {
     const dataItem = this.#data[name] ||
       {
@@ -318,9 +295,9 @@ export default class Data<$ extends DT.Meta>
     const data = {
       ...this.#data,
       ...(await DataItemsParser(
-        this.#payloadParsers,
-        this.#targetingParsers,
-        this.#fallThroughTargetingParsers,
+        this.#schema.payloadParsers,
+        this.#schema.targetingParsers,
+        this.#schema.fallThroughTargetingParsers,
       ).parseAsync({
         [name]: {
           ...dataItem,
@@ -333,14 +310,7 @@ export default class Data<$ extends DT.Meta>
       })),
     }
 
-    return new Data(
-      data,
-      this.#payloadParsers,
-      this.#targetingPredicates,
-      this.#targetingParsers,
-      this.#queryParsers,
-      this.#fallThroughTargetingParsers,
-    )
+    return new Data(this.#schema, data)
   }
 
   /**
@@ -355,14 +325,7 @@ export default class Data<$ extends DT.Meta>
    * ```
    */
   removeAllRules(): Data<$> {
-    return new Data(
-      {} as any,
-      this.#payloadParsers,
-      this.#targetingPredicates,
-      this.#targetingParsers,
-      this.#queryParsers,
-      this.#fallThroughTargetingParsers,
-    )
+    return new Data(this.#schema, {} as DataItemsOut<$>)
   }
 
   /**
@@ -378,7 +341,7 @@ export default class Data<$ extends DT.Meta>
    * ```
    */
   async getPayloadForEachName(
-    rawQuery: QT.Raw<$['QueryParsers']> = {},
+    rawQuery: QT.Raw<$['queryParsers']> = {},
   ): Promise<PT.Payloads<$>> {
     const payloads = {} as PT.Payloads<$>
 
@@ -415,17 +378,17 @@ export default class Data<$ extends DT.Meta>
    * // if region targeting cannot be resolved
    * ```
    */
-  async getPayload<Name extends keyof $['PayloadParsers']>(
+  async getPayload<Name extends keyof $['payloadParsers']>(
     name: Name,
-    rawQuery: QT.Raw<$['QueryParsers']> = {},
+    rawQuery: QT.Raw<$['queryParsers']> = {},
   ): Promise<
-    | PT.Payload<$, $['PayloadParsers'][Name]>
+    | PT.Payload<$, $['payloadParsers'][Name]>
     | undefined
   > {
     const predicate = await this.#createRulePredicate(rawQuery)
     const targetableItem = this.#getTargetableItem(name)
     let payload:
-      | PT.Payload<$, $['PayloadParsers'][Name]>
+      | PT.Payload<$, $['payloadParsers'][Name]>
       | undefined
 
     for (const rule of targetableItem.rules) {
@@ -464,10 +427,10 @@ export default class Data<$ extends DT.Meta>
       : resolvedPayload
   }
 
-  async #getVariables<Name extends keyof $['PayloadParsers']>(
-    targetableItem: DataItemOut<$, $['PayloadParsers'][Name]>,
+  async #getVariables<Name extends keyof $['payloadParsers']>(
+    targetableItem: DataItemOut<$, $['payloadParsers'][Name]>,
     predicate: (
-      rule: DataItemRule<$, $['PayloadParsers'][Name]>,
+      rule: DataItemRule<$, $['payloadParsers'][Name]>,
     ) => Promise<boolean>,
   ) {
     const variables: Record<string, any> = {}
@@ -501,13 +464,13 @@ export default class Data<$ extends DT.Meta>
    * // (if multiple rules matched)
    * ```
    */
-  async getPayloads<Name extends keyof $['PayloadParsers']>(
+  async getPayloads<Name extends keyof $['payloadParsers']>(
     name: Name,
-    rawQuery: QT.Raw<$['QueryParsers']> = {},
+    rawQuery: QT.Raw<$['queryParsers']> = {},
   ): Promise<
-    PT.Payload<$, $['PayloadParsers'][Name]>[]
+    PT.Payload<$, $['payloadParsers'][Name]>[]
   > {
-    const payloads: PT.Payload<$, $['PayloadParsers'][Name]>[] = []
+    const payloads: PT.Payload<$, $['payloadParsers'][Name]>[] = []
     const predicate = await this.#createRulePredicate(rawQuery)
     const targetableItem = this.#getTargetableItem(name)
     for (const rule of targetableItem.rules) {
@@ -532,13 +495,13 @@ export default class Data<$ extends DT.Meta>
       : undefined
   }
 
-  async #createRulePredicate<Name extends keyof $['PayloadParsers']>(
-    rawQuery: QT.Raw<$['QueryParsers']>,
+  async #createRulePredicate<Name extends keyof $['payloadParsers']>(
+    rawQuery: QT.Raw<$['queryParsers']>,
   ) {
     const query = await this.#QueryParser.parseAsync(rawQuery)
 
     return (
-      rule: DataItemRule<$, $['PayloadParsers'][Name]>,
+      rule: DataItemRule<$, $['payloadParsers'][Name]>,
     ) =>
       (
         !('targeting' in rule) ||
@@ -546,7 +509,10 @@ export default class Data<$ extends DT.Meta>
           query as any,
           rule.targeting! as any,
           objectMap(
-            this.#targetingPredicates,
+            this.#schema.targetingPredicates as Record<string, {
+              predicate: (...args: any[]) => any
+              requiresQuery: boolean
+            }>,
             (target, targetingKey) => ({
               predicate: () =>
                 target.predicate(
@@ -562,13 +528,13 @@ export default class Data<$ extends DT.Meta>
       ) as Promise<boolean>
   }
 
-  #getTargetableItem<Name extends keyof $['PayloadParsers']>(name: Name) {
+  #getTargetableItem<Name extends keyof $['payloadParsers']>(name: Name) {
     return (
       (
         this.#data as unknown as {
-          [Name in keyof $['PayloadParsers']]: DataItemOut<
+          [Name in keyof $['payloadParsers']]: DataItemOut<
             $,
-            $['PayloadParsers'][Name]
+            $['payloadParsers'][Name]
           >
         }
       )[name] ?? { rules: [], variables: {} }
@@ -577,14 +543,14 @@ export default class Data<$ extends DT.Meta>
 
   async #targetingPredicate(
     query: $InferObjectOutput<
-      { [K in keyof $['QueryParsers']]: $ZodOptional<$['QueryParsers'][K]> },
+      { [K in keyof $['queryParsers']]: $ZodOptional<$['queryParsers'][K]> },
       {}
     >,
     targeting: MaybeArray<
       $InferObjectOutput<
         {
-          [K in keyof $['TargetingParsers']]: $ZodOptional<
-            $['TargetingParsers'][K]
+          [K in keyof $['targetingParsers']]: $ZodOptional<
+            $['targetingParsers'][K]
           >
         },
         {}

--- a/packages/api/src/DataSchema.ts
+++ b/packages/api/src/DataSchema.ts
@@ -1,33 +1,20 @@
 import { type $ZodShape, $ZodType } from 'zod/v4/core'
 import type TargetingPredicates from './parsers/TargetingPredicates.ts'
-import type * as DT from './types/Data.ts'
 import type * as TT from './types/Targeting.ts'
 import type * as FTTT from './types/FallThroughTargeting.ts'
 import type * as QT from './types/Query.ts'
 import { objectMap } from './util.ts'
 
 /**
- * Opaque, frozen output of {@link DataSchema.build}.
- * Pass this to {@link Data.create} to get a typed {@link Data} instance.
- *
- * The type parameter is a full {@link DT.Meta} — the four accumulated parser
- * shapes from the builder, materialised into the concrete structure
- * {@link Data} expects.
- */
-export interface BuiltDataSchema<$ extends DT.Meta> {
-  readonly payloadParsers: $['PayloadParsers']
-  readonly targetingParsers: $['TargetingParsers']
-  readonly queryParsers: $['QueryParsers']
-  readonly fallThroughTargetingParsers: $['FallThroughTargetingParsers']
-  readonly targetingPredicates: TargetingPredicates<$>
-}
-
-/**
  * Fluent builder for configuring a {@link Data} instance.
  *
- * Each method returns a new builder with intersection-accumulated type
+ * Each method returns a new schema with intersection-accumulated type
  * parameters — this avoids the deep mapped-type instantiation that caused
  * TS2589 when chaining many schema calls directly on {@link Data}.
+ *
+ * The schema is its own public record: pass the result of any
+ * `use*` chain directly into {@link Data.create}; there is no separate
+ * "built" step.
  *
  * **Key uniqueness:** payload, targeting, query, and fall-through targeting
  * names are expected to be unique across calls. Registering the same key
@@ -42,7 +29,6 @@ export interface BuiltDataSchema<$ extends DT.Meta> {
  * const schema = DataSchema.create()
  *   .usePayload({ greeting: z.string() })
  *   .useTargeting({ country: targetIncludes(z.string()) })
- *   .build()
  *
  * const data = await Data.create(schema).addRules('greeting', [
  *   { targeting: { country: ['US'] }, payload: 'Hello!' },
@@ -50,18 +36,18 @@ export interface BuiltDataSchema<$ extends DT.Meta> {
  * ```
  */
 export class DataSchema<
-  PP extends $ZodShape = {},
-  TP extends $ZodShape = {},
-  QP extends $ZodShape = {},
-  FP extends $ZodShape = {},
+  PP extends $ZodShape = $ZodShape,
+  TP extends $ZodShape = $ZodShape,
+  QP extends $ZodShape = $ZodShape,
+  FP extends $ZodShape = $ZodShape,
 > {
-  readonly #payloadParsers: PP
-  readonly #targetingParsers: TP
-  readonly #queryParsers: QP
-  readonly #fallThroughTargetingParsers: FP
-  readonly #targetingPredicates: Record<string, {
-    predicate: (...args: any[]) => any
-    requiresQuery: boolean
+  readonly payloadParsers: PP
+  readonly targetingParsers: TP
+  readonly queryParsers: QP
+  readonly fallThroughTargetingParsers: FP
+  readonly targetingPredicates: TargetingPredicates<{
+    targetingParsers: TP
+    queryParsers: QP
   }>
 
   private constructor(
@@ -69,23 +55,28 @@ export class DataSchema<
     targetingParsers: TP,
     queryParsers: QP,
     fallThroughTargetingParsers: FP,
-    targetingPredicates: Record<string, {
-      predicate: (...args: any[]) => any
-      requiresQuery: boolean
+    targetingPredicates: TargetingPredicates<{
+      targetingParsers: TP
+      queryParsers: QP
     }>,
   ) {
-    this.#payloadParsers = payloadParsers
-    this.#targetingParsers = targetingParsers
-    this.#queryParsers = queryParsers
-    this.#fallThroughTargetingParsers = fallThroughTargetingParsers
-    this.#targetingPredicates = targetingPredicates
+    this.payloadParsers = Object.freeze({ ...payloadParsers })
+    this.targetingParsers = Object.freeze({ ...targetingParsers })
+    this.queryParsers = Object.freeze({ ...queryParsers })
+    this.fallThroughTargetingParsers = Object.freeze({
+      ...fallThroughTargetingParsers,
+    })
+    this.targetingPredicates = Object.freeze({ ...targetingPredicates })
   }
 
   /**
    * Start a new empty configuration.
    */
-  static create(): DataSchema {
-    return new DataSchema({}, {}, {}, {}, {})
+  static create(): DataSchema<{}, {}, {}, {}> {
+    return new DataSchema({}, {}, {}, {}, {} as TargetingPredicates<{
+      targetingParsers: {}
+      queryParsers: {}
+    }>)
   }
 
   /**
@@ -95,11 +86,11 @@ export class DataSchema<
     parsers: P,
   ): DataSchema<PP & P, TP, QP, FP> {
     return new DataSchema(
-      { ...this.#payloadParsers, ...parsers } as PP & P,
-      this.#targetingParsers,
-      this.#queryParsers,
-      this.#fallThroughTargetingParsers,
-      this.#targetingPredicates,
+      { ...this.payloadParsers, ...parsers } as PP & P,
+      this.targetingParsers,
+      this.queryParsers,
+      this.fallThroughTargetingParsers,
+      this.targetingPredicates,
     )
   }
 
@@ -115,25 +106,28 @@ export class DataSchema<
     FP
   > {
     const nextTargetingParsers = {
-      ...this.#targetingParsers,
+      ...this.targetingParsers,
       ...objectMap(targeting, ({ targetingParser }) => targetingParser),
     } as TP & TT.ParserRecord<TDs>
     const nextQueryParsers = {
-      ...this.#queryParsers,
+      ...this.queryParsers,
       ...objectMap(targeting, ({ queryParser }) => queryParser),
     } as QP & QT.ParserRecord<TDs>
     const nextPredicates = {
-      ...this.#targetingPredicates,
+      ...this.targetingPredicates,
       ...objectMap(targeting, (descriptor) => ({
         predicate: descriptor.predicate,
         requiresQuery: descriptor.requiresQuery ?? true,
       })),
-    }
+    } as TargetingPredicates<{
+      targetingParsers: TP & TT.ParserRecord<TDs>
+      queryParsers: QP & QT.ParserRecord<TDs>
+    }>
     return new DataSchema(
-      this.#payloadParsers,
+      this.payloadParsers,
       nextTargetingParsers,
       nextQueryParsers,
-      this.#fallThroughTargetingParsers,
+      this.fallThroughTargetingParsers,
       nextPredicates,
     )
   }
@@ -145,7 +139,7 @@ export class DataSchema<
     targeting: TDs,
   ): DataSchema<PP, TP, QP, FP & FTTT.ParsersRecord<TDs>> {
     const next = {
-      ...this.#fallThroughTargetingParsers,
+      ...this.fallThroughTargetingParsers,
       ...objectMap(
         targeting,
         (descriptorOrParser) =>
@@ -155,44 +149,11 @@ export class DataSchema<
       ),
     } as FP & FTTT.ParsersRecord<TDs>
     return new DataSchema(
-      this.#payloadParsers,
-      this.#targetingParsers,
-      this.#queryParsers,
+      this.payloadParsers,
+      this.targetingParsers,
+      this.queryParsers,
       next,
-      this.#targetingPredicates,
+      this.targetingPredicates,
     )
-  }
-
-  /**
-   * Materialise the accumulated configuration into a {@link BuiltDataSchema}
-   * suitable for passing to {@link Data.create}.
-   *
-   * The returned object and each nested parser record are frozen, so the
-   * built schema is safe to share between {@link Data} instances without
-   * risk of external mutation changing behaviour.
-   */
-  build(): BuiltDataSchema<{
-    PayloadParsers: PP
-    TargetingParsers: TP
-    QueryParsers: QP
-    FallThroughTargetingParsers: FP
-  }> {
-    type $ = {
-      PayloadParsers: PP
-      TargetingParsers: TP
-      QueryParsers: QP
-      FallThroughTargetingParsers: FP
-    }
-    return Object.freeze({
-      payloadParsers: Object.freeze({ ...this.#payloadParsers }),
-      targetingParsers: Object.freeze({ ...this.#targetingParsers }),
-      queryParsers: Object.freeze({ ...this.#queryParsers }),
-      fallThroughTargetingParsers: Object.freeze({
-        ...this.#fallThroughTargetingParsers,
-      }),
-      targetingPredicates: Object.freeze({
-        ...this.#targetingPredicates,
-      }) as TargetingPredicates<$>,
-    })
   }
 }

--- a/packages/api/src/InsertableData.ts
+++ b/packages/api/src/InsertableData.ts
@@ -1,9 +1,10 @@
+import type { DataSchema } from './DataSchema.ts'
 import type * as DT from './types/Data.ts'
 
 /**
  * Interface for inserting rule data into a {@link Data} instance.
  *
- * @template $ - The metadata type extending {@link DT.Meta}
+ * @template $ - The {@link DataSchema} type.
  *
  * @example
  * ```ts
@@ -12,7 +13,7 @@ import type * as DT from './types/Data.ts'
  * })
  * ```
  */
-export interface InsertableData<$ extends DT.Meta> {
+export interface InsertableData<$ extends DataSchema> {
   /**
    * Insert rule data into the instance.
    *

--- a/packages/api/src/PromisedData.ts
+++ b/packages/api/src/PromisedData.ts
@@ -1,4 +1,5 @@
 import type Data from './Data.ts'
+import type { DataSchema } from './DataSchema.ts'
 import type * as DT from './types/Data.ts'
 import type * as PT from './types/Payload.ts'
 import type * as QT from './types/Query.ts'
@@ -16,12 +17,12 @@ import type { QueryableData } from './QueryableData.ts'
  * Produced by {@link Data.create}; schema configuration lives on
  * {@link DataSchema} and happens before the PromisedData is created.
  *
- * @template $ - The metadata type extending Data.Meta
+ * @template $ - The {@link DataSchema} type.
  * @extends {Promise<Data<$>>}
  * @implements {InsertableData<$>}
  * @implements {QueryableData<$>}
  */
-export class PromisedData<$ extends DT.Meta> extends Promise<Data<$>>
+export class PromisedData<$ extends DataSchema> extends Promise<Data<$>>
   implements InsertableData<$>, QueryableData<$> {
   /**
    * Creates a new PromisedData instance.
@@ -40,11 +41,11 @@ export class PromisedData<$ extends DT.Meta> extends Promise<Data<$>>
   /**
    * Factory method to create a PromisedData instance from a Data instance or Promise.
    *
-   * @template $ - The metadata type extending Data.Meta
+   * @template $ - The {@link DataSchema} type.
    * @param promisedData - A Data instance or a Promise that resolves to a Data instance
    * @returns A new PromisedData instance
    */
-  static create<$ extends DT.Meta>(
+  static create<$ extends DataSchema>(
     promisedData: MaybePromise<Data<$>>,
   ): PromisedData<$> {
     return new PromisedData((resolve) => resolve(promisedData))
@@ -79,12 +80,12 @@ export class PromisedData<$ extends DT.Meta> extends Promise<Data<$>>
    * @returns A new PromisedData instance with the added rules
    */
   addRules<
-    Name extends keyof $['PayloadParsers'],
+    Name extends keyof $['payloadParsers'],
   >(
     name: Name,
     opts:
-      | DataItemIn<$, $['PayloadParsers'][Name]>
-      | DataItemRulesIn<$, $['PayloadParsers'][Name]>,
+      | DataItemIn<$, $['payloadParsers'][Name]>
+      | DataItemRulesIn<$, $['payloadParsers'][Name]>,
   ): PromisedData<$> {
     return this.#create((data) => data.addRules(name, opts))
   }
@@ -96,7 +97,7 @@ export class PromisedData<$ extends DT.Meta> extends Promise<Data<$>>
    * @returns A Promise that resolves to an object containing payloads for each name
    */
   async getPayloadForEachName(
-    rawQuery?: QT.Raw<$['QueryParsers']>,
+    rawQuery?: QT.Raw<$['queryParsers']>,
   ): Promise<
     PT.Payloads<$>
   > {
@@ -112,11 +113,11 @@ export class PromisedData<$ extends DT.Meta> extends Promise<Data<$>>
    * @param rawQuery - Optional raw query object for filtering
    * @returns A Promise that resolves to the payload or undefined if not found
    */
-  async getPayload<Name extends keyof $['PayloadParsers']>(
+  async getPayload<Name extends keyof $['payloadParsers']>(
     name: Name,
-    rawQuery?: QT.Raw<$['QueryParsers']>,
+    rawQuery?: QT.Raw<$['queryParsers']>,
   ): Promise<
-    | PT.Payload<$, $['PayloadParsers'][Name]>
+    | PT.Payload<$, $['payloadParsers'][Name]>
     | undefined
   > {
     const data = await this
@@ -131,11 +132,11 @@ export class PromisedData<$ extends DT.Meta> extends Promise<Data<$>>
    * @param rawQuery - Optional raw query object for filtering
    * @returns A Promise that resolves to an array of payloads
    */
-  async getPayloads<Name extends keyof $['PayloadParsers']>(
+  async getPayloads<Name extends keyof $['payloadParsers']>(
     name: Name,
-    rawQuery?: QT.Raw<$['QueryParsers']>,
+    rawQuery?: QT.Raw<$['queryParsers']>,
   ): Promise<
-    PT.Payload<$, $['PayloadParsers'][Name]>[]
+    PT.Payload<$, $['payloadParsers'][Name]>[]
   > {
     const data = await this
     return data.getPayloads(name, rawQuery)

--- a/packages/api/src/QueryableData.ts
+++ b/packages/api/src/QueryableData.ts
@@ -1,11 +1,11 @@
-import type * as DT from './types/Data.ts'
+import type { DataSchema } from './DataSchema.ts'
 import type * as PT from './types/Payload.ts'
 import type * as QT from './types/Query.ts'
 
 /**
  * Interface for querying payloads from a {@link Data} instance.
  *
- * @template $ - The metadata type extending {@link DT.Meta}
+ * @template $ - The {@link DataSchema} type.
  *
  * @example
  * ```ts
@@ -13,7 +13,7 @@ import type * as QT from './types/Query.ts'
  * const all = await data.getPayloadForEachName({ country: 'US' })
  * ```
  */
-export interface QueryableData<$ extends DT.Meta> {
+export interface QueryableData<$ extends DataSchema> {
   /**
    * Retrieve the first matching payload for every registered payload name.
    *
@@ -21,7 +21,7 @@ export interface QueryableData<$ extends DT.Meta> {
    * @returns An object mapping payload names to their matched values.
    */
   getPayloadForEachName(
-    rawQuery?: QT.Raw<$['QueryParsers']>,
+    rawQuery?: QT.Raw<$['queryParsers']>,
   ): Promise<PT.Payloads<$>>
 
   /**
@@ -31,11 +31,11 @@ export interface QueryableData<$ extends DT.Meta> {
    * @param rawQuery - Optional query object for targeting.
    * @returns The matched payload, or `undefined` if no rule matched.
    */
-  getPayload<Name extends keyof $['PayloadParsers']>(
+  getPayload<Name extends keyof $['payloadParsers']>(
     name: Name,
-    rawQuery?: QT.Raw<$['QueryParsers']>,
+    rawQuery?: QT.Raw<$['queryParsers']>,
   ): Promise<
-    | PT.Payload<$, $['PayloadParsers'][Name]>
+    | PT.Payload<$, $['payloadParsers'][Name]>
     | undefined
   >
 
@@ -46,10 +46,10 @@ export interface QueryableData<$ extends DT.Meta> {
    * @param rawQuery - Optional query object for targeting.
    * @returns An array of all matching payloads.
    */
-  getPayloads<Name extends keyof $['PayloadParsers']>(
+  getPayloads<Name extends keyof $['payloadParsers']>(
     name: Name,
-    rawQuery?: QT.Raw<$['QueryParsers']>,
+    rawQuery?: QT.Raw<$['queryParsers']>,
   ): Promise<
-    PT.Payload<$, $['PayloadParsers'][Name]>[]
+    PT.Payload<$, $['payloadParsers'][Name]>[]
   >
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,7 +1,6 @@
 export { default as Data } from './Data.ts'
 export * from './PromisedData.ts'
 export { DataSchema } from './DataSchema.ts'
-export type { BuiltDataSchema } from './DataSchema.ts'
 export { DataItemParser } from './parsers/DataItem.ts'
 export { DataItemsParser } from './parsers/DataItems.ts'
 export { DataItemRuleParser } from './parsers/DataItemRule.ts'

--- a/packages/api/src/parsers/DataItem.ts
+++ b/packages/api/src/parsers/DataItem.ts
@@ -57,7 +57,7 @@ export function DataItemParser<
 /**
  * Zod parser type for a single data item with rules and variables.
  *
- * @template $ - Data meta configuration.
+ * @template $ - Data schema
  * @template PayloadParser - Zod parser for the payload type.
  */
 export type DataItemParser<

--- a/packages/api/src/parsers/DataItem.ts
+++ b/packages/api/src/parsers/DataItem.ts
@@ -13,7 +13,7 @@ import {
 } from './DataItemRules.ts'
 import { DataItemVariablesParser } from './DataItemVariablesParser.ts'
 import { variablesFor } from './variablesRegistry.ts'
-import type * as DT from '../types/Data.ts'
+import type { DataSchema } from '../DataSchema.ts'
 
 /**
  * Parses an "item".
@@ -25,12 +25,12 @@ import type * as DT from '../types/Data.ts'
  * Currently this is just restricted to `rules`.
  */
 export function DataItemParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 >(
   Payload: PayloadParser,
-  targeting: $['TargetingParsers'],
-  fallThroughTargeting: $['FallThroughTargetingParsers'],
+  targeting: $['targetingParsers'],
+  fallThroughTargeting: $['fallThroughTargetingParsers'],
   strictTargeting: boolean,
 ): DataItemParser<$, PayloadParser> {
   const variablesRegistry = variablesFor(Payload)
@@ -61,7 +61,7 @@ export function DataItemParser<
  * @template PayloadParser - Zod parser for the payload type.
  */
 export type DataItemParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 > = ZodMiniObject<
   {
@@ -75,7 +75,7 @@ export type DataItemParser<
  * The data shape expected for {@link DataItemParser} inputs.
  */
 export interface DataItemIn<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 > {
   rules: DataItemRulesIn<$, PayloadParser>
@@ -89,7 +89,7 @@ export interface DataItemIn<
  * The data shape expected for {@link DataItemParser} outputs.
  */
 export interface DataItemOut<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 > {
   rules: DataItemRulesOut<$, PayloadParser>

--- a/packages/api/src/parsers/DataItemRule.ts
+++ b/packages/api/src/parsers/DataItemRule.ts
@@ -17,7 +17,7 @@ import {
   type RecursiveVariableResolver,
 } from './attachVariableResolver.ts'
 import type { VariablesRegistry } from './variablesRegistry.ts'
-import type * as DT from '../types/Data.ts'
+import type { DataSchema } from '../DataSchema.ts'
 
 /**
  * Parses a single item rule.
@@ -89,15 +89,15 @@ import type * as DT from '../types/Data.ts'
  * ```
  */
 export function DataItemRuleParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
   VariableRegistry extends Record<string, any>,
   AllowMultipleTargeting extends boolean = true,
 >(
   variablesRegistry: VariablesRegistry,
   Payload: PayloadParser,
-  targeting: $['TargetingParsers'],
-  fallThroughTargeting: $['FallThroughTargetingParsers'],
+  targeting: $['targetingParsers'],
+  fallThroughTargeting: $['fallThroughTargetingParsers'],
   allowMultipleTargeting = true,
 ): DataItemRuleParser<
   $,
@@ -127,7 +127,7 @@ export function DataItemRuleParser<
 }
 
 export type DataItemRuleParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
   AllowMultipleTargeting extends boolean = true,
 > = ZodMiniUnion<
@@ -145,13 +145,13 @@ export type DataItemRuleParser<
  * @template AllowMultipleTargeting - Whether multiple targeting values are allowed.
  */
 export type DataItemRule<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
   AllowMultipleTargeting extends boolean = true,
 > =
   | RuleWithPayload<
     PayloadParser,
-    $['TargetingParsers'],
+    $['targetingParsers'],
     AllowMultipleTargeting
   >
   | RuleWithFallThrough<$, PayloadParser, AllowMultipleTargeting>
@@ -192,7 +192,7 @@ function MultipleRuleTargeting<Targeting extends $ZodShape>(
  * @template AllowMultipleTargeting - Whether multiple targeting values are allowed.
  */
 export type RuleWithPayloadParser<
-  $ extends Pick<DT.Meta, 'TargetingParsers'>,
+  $ extends Pick<DataSchema, 'targetingParsers'>,
   Payload extends $ZodType,
   AllowMultipleTargeting extends boolean = true,
 > = ZodMiniObject<
@@ -200,8 +200,8 @@ export type RuleWithPayloadParser<
     payload: RecursiveVariableResolver<Payload>
     targeting: ZodMiniOptional<
       AllowMultipleTargeting extends true
-        ? MultipleRuleTargeting<$['TargetingParsers']>
-        : SingularRuleTargeting<$['TargetingParsers']>
+        ? MultipleRuleTargeting<$['targetingParsers']>
+        : SingularRuleTargeting<$['targetingParsers']>
     >
   },
   $strict
@@ -216,13 +216,13 @@ export type RuleWithPayloadParser<
  * @template AllowMultipleTargeting - Whether multiple targeting values are allowed.
  */
 export function RuleWithPayloadParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
   AllowMultipleTargeting extends boolean = true,
 >(
   variablesRegistry: VariablesRegistry,
   Payload: PayloadParser,
-  targeting: $['TargetingParsers'] & $['FallThroughTargetingParsers'],
+  targeting: $['targetingParsers'] & $['fallThroughTargetingParsers'],
   strictTargeting: boolean,
   allowMultipleTargeting = true as AllowMultipleTargeting,
 ): RuleWithPayloadParser<$, PayloadParser, AllowMultipleTargeting> {
@@ -247,17 +247,17 @@ export function RuleWithPayloadParser<
  * @see https://github.com/colinhacks/zod/issues/4698
  */
 export interface RuleWithPayloadIn<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
   AllowMultipleTargeting extends boolean = true,
 > {
   payload: input<RecursiveVariableResolver<PayloadParser>>
   targeting?: input<
     AllowMultipleTargeting extends true ? MultipleRuleTargeting<
-        $['TargetingParsers'] & $['FallThroughTargetingParsers']
+        $['targetingParsers'] & $['fallThroughTargetingParsers']
       >
       : SingularRuleTargeting<
-        $['TargetingParsers'] & $['FallThroughTargetingParsers']
+        $['targetingParsers'] & $['fallThroughTargetingParsers']
       >
   >
 }
@@ -285,15 +285,15 @@ export interface RuleWithPayload<
 }
 
 export type RuleWithFallThroughParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
   AllowMultipleTargeting extends boolean = true,
 > = ZodMiniObject<
   {
     targeting: ZodMiniOptional<
       AllowMultipleTargeting extends true
-        ? MultipleRuleTargeting<$['TargetingParsers']>
-        : SingularRuleTargeting<$['TargetingParsers']>
+        ? MultipleRuleTargeting<$['targetingParsers']>
+        : SingularRuleTargeting<$['targetingParsers']>
     >
     fallThrough: ZodMiniArray<
       RuleWithPayloadParser<
@@ -317,32 +317,32 @@ export type RuleWithFallThroughParser<
  * @see https://github.com/colinhacks/zod/issues/4698
  */
 export interface RuleWithFallThrough<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
   AllowMultipleTargeting extends boolean = true,
 > {
   fallThrough: RuleWithPayload<
     PayloadParser,
-    $['FallThroughTargetingParsers'],
+    $['fallThroughTargetingParsers'],
     AllowMultipleTargeting
   >[]
   targeting?: output<
     AllowMultipleTargeting extends true
-      ? MultipleRuleTargeting<$['TargetingParsers']>
-      : SingularRuleTargeting<$['TargetingParsers']>
+      ? MultipleRuleTargeting<$['targetingParsers']>
+      : SingularRuleTargeting<$['targetingParsers']>
   >
 }
 
 export function RuleWithFallThroughParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
   Variables extends Record<string, any>,
   AllowMultipleTargeting extends boolean = true,
 >(
   variablesRegistry: VariablesRegistry,
   payload: PayloadParser,
-  targeting: $['TargetingParsers'],
-  fallThroughTargeting: $['FallThroughTargetingParsers'],
+  targeting: $['targetingParsers'],
+  fallThroughTargeting: $['fallThroughTargetingParsers'],
   strictTargeting: boolean,
   allowMultipleTargeting = true,
 ): RuleWithFallThroughParser<$, PayloadParser, AllowMultipleTargeting> {

--- a/packages/api/src/parsers/DataItemRule.ts
+++ b/packages/api/src/parsers/DataItemRule.ts
@@ -211,7 +211,7 @@ export type RuleWithPayloadParser<
  * Creates a Zod parser for rules with direct payload values.
  * Handles targeting conditions and payload parsing with variable resolution.
  *
- * @template $ - Data meta configuration.
+ * @template $ - Data schema
  * @template PayloadParser - Zod parser for the payload type.
  * @template AllowMultipleTargeting - Whether multiple targeting values are allowed.
  */

--- a/packages/api/src/parsers/DataItemRules.ts
+++ b/packages/api/src/parsers/DataItemRules.ts
@@ -21,7 +21,7 @@ import {
 } from 'zod/mini'
 import type { $ZodShape, $ZodType } from 'zod/v4/core'
 import type { ZodPartialInferObject } from '../types.ts'
-import type * as DT from '../types/Data.ts'
+import type { DataSchema } from '../DataSchema.ts'
 import type { VariablesRegistry } from './variablesRegistry.ts'
 
 /**
@@ -59,13 +59,13 @@ import type { VariablesRegistry } from './variablesRegistry.ts'
  * ```
  */
 export function DataItemRulesParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 >(
   variablesRegistry: VariablesRegistry,
   payloadParser: PayloadParser,
-  targetingParsers: $['TargetingParsers'],
-  fallThroughTargetingParsers: $['FallThroughTargetingParsers'],
+  targetingParsers: $['targetingParsers'],
+  fallThroughTargetingParsers: $['fallThroughTargetingParsers'],
   strictTargeting: boolean,
 ): DataItemRulesParser<$, PayloadParser> {
   return pipe(
@@ -141,7 +141,7 @@ export function DataItemRulesParser<
 }
 
 export type DataItemRulesParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 > = ZodMiniPipe<
   ZodMiniArray<RuleWithPayloadParser<$, PayloadParser>>,
@@ -152,7 +152,7 @@ export type DataItemRulesParser<
 >
 
 export type DataItemRulesIn<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 > = RuleWithPayloadIn<$, PayloadParser>[]
 /**
@@ -162,12 +162,12 @@ export type DataItemRulesIn<
  * @template $ - Data meta configuration.
  * @template PayloadParser - Zod parser for the payload type.
  */ export type DataItemRulesOut<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 > = DataItemRule<$, PayloadParser, false>[]
 
 function spreadMultiTargetsToSeparateRules<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 >(rules: RuleWithPayloadIn<$, PayloadParser>[]) {
   return rules.reduce<RuleWithPayloadIn<$, PayloadParser, false>[]>(
@@ -190,8 +190,8 @@ function spreadMultiTargetsToSeparateRules<
 
 function canRulesCombine(
   targetingParsers: $ZodShape,
-  a: DataItemRule<DT.Meta, $ZodType, false>,
-  b: DataItemRule<DT.Meta, $ZodType, false>,
+  a: DataItemRule<DataSchema, $ZodType, false>,
+  b: DataItemRule<DataSchema, $ZodType, false>,
 ) {
   const aTargeting = a.targeting
     ? intersection(a.targeting, targetingParsers)
@@ -214,11 +214,11 @@ function canRulesCombine(
 }
 
 function adaptRule<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 >(
-  targetingParsers: $['TargetingParsers'],
-  fallThroughTargetingParsers: $['FallThroughTargetingParsers'],
+  targetingParsers: $['targetingParsers'],
+  fallThroughTargetingParsers: $['fallThroughTargetingParsers'],
   rule: RuleWithPayloadIn<$, PayloadParser, false>,
 ) {
   return (
@@ -233,11 +233,11 @@ function adaptRule<
 }
 
 function adaptRuleIntoFallThroughRule<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 >(
-  targetingParsers: $['TargetingParsers'],
-  fallThroughTargetingParsers: $['FallThroughTargetingParsers'],
+  targetingParsers: $['targetingParsers'],
+  fallThroughTargetingParsers: $['fallThroughTargetingParsers'],
   rule: DataItemRule<$, PayloadParser, false>,
 ): RuleWithFallThrough<$, PayloadParser, false> {
   if ('fallThrough' in rule) return rule
@@ -245,7 +245,7 @@ function adaptRuleIntoFallThroughRule<
     targeting: intersection(
       rule.targeting || {},
       targetingParsers,
-    ) as ZodPartialInferObject<$['TargetingParsers']>,
+    ) as ZodPartialInferObject<$['targetingParsers']>,
     fallThrough: [
       {
         payload: rule.payload,

--- a/packages/api/src/parsers/DataItemVariablesParser.ts
+++ b/packages/api/src/parsers/DataItemVariablesParser.ts
@@ -10,12 +10,12 @@ import {
 } from 'zod/mini'
 import { DataItemRulesParser } from './DataItemRules.ts'
 import type { VariablesRegistry } from './variablesRegistry.ts'
-import type * as DT from '../types/Data.ts'
+import type { DataSchema } from '../DataSchema.ts'
 
-export function DataItemVariablesParser<$ extends DT.Meta>(
+export function DataItemVariablesParser<$ extends DataSchema>(
   variablesRegistry: VariablesRegistry,
-  targeting: $['TargetingParsers'],
-  fallThroughTargeting: $['FallThroughTargetingParsers'],
+  targeting: $['targetingParsers'],
+  fallThroughTargeting: $['fallThroughTargetingParsers'],
   strictTargeting: boolean,
 ): DataItemVariablesParser<$> {
   return record(
@@ -87,7 +87,7 @@ export function DataItemVariablesParser<$ extends DT.Meta>(
   })
 }
 
-export type DataItemVariablesParser<$ extends DT.Meta> = ZodMiniRecord<
+export type DataItemVariablesParser<$ extends DataSchema> = ZodMiniRecord<
   ZodMiniString<string>,
   DataItemRulesParser<$, ZodMiniAny>
 >

--- a/packages/api/src/parsers/DataItems.ts
+++ b/packages/api/src/parsers/DataItems.ts
@@ -1,4 +1,4 @@
-import type * as DT from '../types/Data.ts'
+import type { DataSchema } from '../DataSchema.ts'
 import type { ObjValues, ZodPartialObject } from '../types.ts'
 import {
   type DataItemIn,
@@ -31,17 +31,17 @@ import type { $strict } from 'zod/v4/core'
  * ```
  */
 export function DataItemsParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
 >(
-  payloadParsers: $['PayloadParsers'],
-  targeting: $['TargetingParsers'],
-  fallThroughTargeting: $['FallThroughTargetingParsers'],
+  payloadParsers: $['payloadParsers'],
+  targeting: $['targetingParsers'],
+  fallThroughTargeting: $['fallThroughTargetingParsers'],
   strict = true,
 ): DataItemsParser<$> {
   const dataItems: Record<string, any> = {}
   for (const [key, Payload] of Object.entries(payloadParsers)) {
     dataItems[key] = DataItemParser(
-      Payload as ObjValues<$['PayloadParsers']>,
+      Payload as ObjValues<$['payloadParsers']>,
       targeting,
       fallThroughTargeting,
       strict,
@@ -59,12 +59,12 @@ export function DataItemsParser<
  * @template $ - Data meta configuration.
  */
 export type DataItemsParser<
-  $ extends DT.Meta,
+  $ extends DataSchema,
 > = ZodPartialObject<
   {
-    [Name in keyof $['PayloadParsers']]: DataItemParser<
+    [Name in keyof $['payloadParsers']]: DataItemParser<
       $,
-      $['PayloadParsers'][Name]
+      $['payloadParsers'][Name]
     >
   },
   $strict
@@ -74,21 +74,21 @@ export type DataItemsParser<
  * Input type for {@link DataItemsParser}.
  * Maps payload names to their item input configurations.
  *
- * @template $ - Data meta configuration.
+ * @template $ - DataSchema type.
  */
-export type DataItemsIn<$ extends DT.Meta> = {
-  [Name in keyof $['PayloadParsers']]?: DataItemIn<$, $['PayloadParsers'][Name]>
+export type DataItemsIn<$ extends DataSchema> = {
+  [Name in keyof $['payloadParsers']]?: DataItemIn<$, $['payloadParsers'][Name]>
 }
 
 /**
  * Output type for {@link DataItemsParser}.
  * Maps payload names to their item output configurations.
  *
- * @template $ - Data meta configuration.
+ * @template $ - DataSchema type.
  */
-export type DataItemsOut<$ extends DT.Meta> = {
-  [Name in keyof $['PayloadParsers']]?: DataItemOut<
+export type DataItemsOut<$ extends DataSchema> = {
+  [Name in keyof $['payloadParsers']]?: DataItemOut<
     $,
-    $['PayloadParsers'][Name]
+    $['payloadParsers'][Name]
   >
 }

--- a/packages/api/src/parsers/DataItems.ts
+++ b/packages/api/src/parsers/DataItems.ts
@@ -56,7 +56,7 @@ export function DataItemsParser<
  * Zod parser for all items in a Data instance.
  * Returns a partial object where each key is a payload name.
  *
- * @template $ - Data meta configuration.
+ * @template $ - DataSchema type.
  */
 export type DataItemsParser<
   $ extends DataSchema,

--- a/packages/api/src/parsers/TargetingPredicates.ts
+++ b/packages/api/src/parsers/TargetingPredicates.ts
@@ -1,22 +1,29 @@
 import type { Keys } from 'ts-toolbelt/out/Any/Keys'
 import type TargetingPredicate from './TargetingPredicate.ts'
-import type * as DT from '../types/Data.ts'
-import type { $InferObjectOutput, $strict, output } from 'zod/v4/core'
+import type {
+  $InferObjectOutput,
+  $strict,
+  $ZodShape,
+  output,
+} from 'zod/v4/core'
 
 /**
  * Maps targeting field names to their predicate functions and requirements.
  * Used internally to configure how each targeting field is evaluated.
  *
- * @template $ - Data meta configuration with TargetingParsers and QueryParsers.
+ * @template $ - Shape with `targetingParsers` and `queryParsers`.
  */
 type TargetingPredicates<
-  $ extends Pick<DT.Meta, 'TargetingParsers' | 'QueryParsers'>,
+  $ extends {
+    targetingParsers: $ZodShape
+    queryParsers: $ZodShape
+  },
 > = {
-  [Name in Keys<$['TargetingParsers']>]: {
+  [Name in Keys<$['targetingParsers']>]: {
     predicate: TargetingPredicate<
-      $['QueryParsers'][Name],
-      $['TargetingParsers'][Name],
-      Partial<output<$InferObjectOutput<$['QueryParsers'], $strict>>>
+      $['queryParsers'][Name],
+      $['targetingParsers'][Name],
+      Partial<output<$InferObjectOutput<$['queryParsers'], $strict>>>
     >
     requiresQuery: boolean
   }

--- a/packages/api/src/predicates/equals.ts
+++ b/packages/api/src/predicates/equals.ts
@@ -17,8 +17,7 @@ import type { $ZodType } from 'zod/v4/core'
  * const data = await Data.create(
  *   DataSchema.create()
  *     .usePayload({ feature: z.string() })
- *     .useTargeting({ isPremium: targetEquals(z.boolean()) })
- *     .build(),
+ *     .useTargeting({ isPremium: targetEquals(z.boolean()) }),
  * ).addRules('feature', [
  *   { targeting: { isPremium: true }, payload: 'Premium feature' },
  *   { payload: 'Basic feature' }

--- a/packages/api/src/predicates/targetIncludes.ts
+++ b/packages/api/src/predicates/targetIncludes.ts
@@ -19,8 +19,7 @@ import { array } from 'zod/mini'
  * const data = await Data.create(
  *   DataSchema.create()
  *     .usePayload({ content: z.string() })
- *     .useTargeting({ country: targetIncludes(z.string()) })
- *     .build(),
+ *     .useTargeting({ country: targetIncludes(z.string()) }),
  * ).addRules('content', [
  *   { targeting: { country: ['US', 'CA'] }, payload: 'North America content' },
  *   { targeting: { country: ['UK', 'FR'] }, payload: 'Europe content' },

--- a/packages/api/src/types/Data.ts
+++ b/packages/api/src/types/Data.ts
@@ -1,89 +1,27 @@
-import type Data from '../Data.ts'
+import type { DataSchema } from '../DataSchema.ts'
 import type * as FTTT from './FallThroughTargeting.ts'
-import type { $ZodShape, output } from 'zod/v4/core'
-
-/**
- * Configuration metadata for a Data instance.
- * Defines the Zod parsers for payloads, targeting, queries, and fallthrough targeting.
- */
-export interface Meta {
-  PayloadParsers: $ZodShape
-  TargetingParsers: $ZodShape
-  QueryParsers: $ZodShape
-  FallThroughTargetingParsers: $ZodShape
-}
-
-/**
- * Empty metadata configuration for Data instances with no parsers defined.
- */
-export interface EmptyMeta {
-  PayloadParsers: {}
-  TargetingParsers: {}
-  QueryParsers: {}
-  FallThroughTargetingParsers: {}
-}
-
-/**
- * Match any Data
- */
-export type Any = Data<
-  {
-    PayloadParsers: any
-    TargetingParsers: any
-    QueryParsers: any
-    FallThroughTargetingParsers: any
-  }
->
-
-/**
- * Extract the Meta configuration from a Data type.
- *
- * @template D - Any Data instance type.
- */
-export type $<D extends Any> = D extends Data<infer $> ? $ : never
-
-/**
- * Get the PayloadParsers from a Data type
- */
-export type PayloadParsers<D extends Any> = $<D>['PayloadParsers']
-
-/**
- * Get the TargetingParsers from a Data type
- */
-export type TargetingParsers<D extends Any> = $<D>['TargetingParsers']
-
-/**
- * Get the QueryParsers from a Data type
- */
-export type QueryParsers<D extends Any> = $<D>['QueryParsers']
-
-/**
- * Get the FallThroughTargetingParsers from a Data type
- */
-export type FallThroughTargetingParsers<D extends Any> = $<
-  D
->['FallThroughTargetingParsers']
+import type { output } from 'zod/v4/core'
 
 /**
  * Data shape that can be inserted into a Data instance.
  * Maps payload names to their values or rule sets.
  *
- * @template $ - Data meta configuration.
+ * @template $ - DataSchema type.
  */
-export type InsertableData<$ extends Meta> = Partial<
+export type InsertableData<$ extends DataSchema> = Partial<
   {
-    [Name in keyof $['PayloadParsers']]:
-      | output<$['PayloadParsers'][Name]>
+    [Name in keyof $['payloadParsers']]:
+      | output<$['payloadParsers'][Name]>
       | FTTT.Rules<
         $,
-        $['PayloadParsers'][Name]
+        $['payloadParsers'][Name]
       >
       | FTTT.Rules<
         $ & {
-          TargetingParsers: {}
-          FallThroughTargetingParsers: $['TargetingParsers']
+          targetingParsers: {}
+          fallThroughTargetingParsers: $['targetingParsers']
         },
-        $['PayloadParsers'][Name]
+        $['payloadParsers'][Name]
       >
   }
 >

--- a/packages/api/src/types/FallThroughTargeting.ts
+++ b/packages/api/src/types/FallThroughTargeting.ts
@@ -3,7 +3,7 @@ import type * as TT from './Targeting.ts'
 import type { RuleWithPayload } from '../parsers/DataItemRule.ts'
 import type { $ZodType } from 'zod/v4/core'
 import type { DataItemRulesOut } from '../parsers/DataItemRules.ts'
-import type * as DT from './Data.ts'
+import type { DataSchema } from '../DataSchema.ts'
 import type { ZodMiniAny } from 'zod/mini'
 
 /**
@@ -38,18 +38,18 @@ export type ParsersRecord<TDs extends DescriptorRecord> = {
  * Represents a set of fallthrough targeting rules with optional variables.
  * Used when a payload depends on additional targeting conditions.
  *
- * @template $ - Data meta configuration.
+ * @template $ - DataSchema type.
  * @template PayloadParser - Zod parser for the payload type.
  */
 export type Rules<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 > = {
-  __rules__: RuleWithPayload<PayloadParser, $['FallThroughTargetingParsers']>[]
+  __rules__: RuleWithPayload<PayloadParser, $['fallThroughTargetingParsers']>[]
   __variables__?: Record<
     string,
     DataItemRulesOut<
-      $ & { TargetingParsers: $['FallThroughTargetingParsers'] },
+      $ & { targetingParsers: $['fallThroughTargetingParsers'] },
       ZodMiniAny
     >
   >

--- a/packages/api/src/types/Payload.ts
+++ b/packages/api/src/types/Payload.ts
@@ -1,15 +1,15 @@
 import type { $ZodType, output } from 'zod/v4/core'
 import type * as FTTT from './FallThroughTargeting.ts'
-import type * as DT from './Data.ts'
+import type { DataSchema } from '../DataSchema.ts'
 
 /**
  * A payload value that can be either a direct value or a set of fallthrough rules.
  *
- * @template $ - Data meta configuration.
+ * @template $ - DataSchema type.
  * @template PayloadParser - Zod parser for the payload type.
  */
 export type Payload<
-  $ extends DT.Meta,
+  $ extends DataSchema,
   PayloadParser extends $ZodType,
 > =
   | output<PayloadParser>
@@ -19,8 +19,8 @@ export type Payload<
  * Maps payload names to their Payload values.
  * Used to represent all payloads in a Data instance.
  *
- * @template $ - Data meta configuration.
+ * @template $ - DataSchema type.
  */
-export type Payloads<$ extends DT.Meta> = {
-  [Name in keyof $['PayloadParsers']]?: Payload<$, $['PayloadParsers'][Name]>
+export type Payloads<$ extends DataSchema> = {
+  [Name in keyof $['payloadParsers']]?: Payload<$, $['payloadParsers'][Name]>
 }

--- a/packages/api/test/Data.test.ts
+++ b/packages/api/test/Data.test.ts
@@ -27,8 +27,7 @@ Deno.test('getPayload', async () => {
           queryParser: z.boolean(),
           targetingParser: z.boolean(),
         },
-      })
-      .build(),
+      }),
   )
     .addRules('foo', [
       {
@@ -108,8 +107,7 @@ Deno.test('targeting with multiple conditions', async () => {
       .useTargeting({
         weather: targetIncludes(z.string()),
         highTide: targetEquals(z.boolean()),
-      })
-      .build(),
+      }),
   )
     .addRules('foo', [
       {
@@ -152,8 +150,7 @@ Deno.test('targeting without requiring a query', async () => {
           requiresQuery: false,
           targetingParser: z.literal('now!'),
         },
-      })
-      .build(),
+      }),
   )
     .addRules('foo', [
       {
@@ -179,8 +176,7 @@ Deno.test('getPayloads', async (t) => {
       .useTargeting({
         weather: targetIncludes(z.string()),
         highTide: targetEquals(z.boolean()),
-      })
-      .build(),
+      }),
   )
     .addRules('foo', [
       {
@@ -215,8 +211,7 @@ Deno.test('payload runtype validation', async (t) => {
       DataSchema.create()
         .usePayload({
           foo: z.string().refine((x) => x === 'bar', 'Should be bar'),
-        })
-        .build(),
+        }),
     )
       .addRules('foo', [
         {
@@ -247,8 +242,7 @@ Deno.test('getPayloadForEachName', async (t) => {
           queryParser: z.boolean(),
           targetingParser: z.boolean(),
         },
-      })
-      .build(),
+      }),
   )
     .addRules('foo', [
       {
@@ -304,8 +298,7 @@ Deno.test('fallThrough targeting', async (t) => {
         mung: z.string(),
       })
       .useTargeting({ surf: targetIncludes(z.string(), { withNegate: true }) })
-      .useFallThroughTargeting({ weather: z.array(z.string()) })
-      .build(),
+      .useFallThroughTargeting({ weather: z.array(z.string()) }),
   )
     .addRules('foo', [
       {
@@ -380,8 +373,7 @@ Deno.test('inserting data', async (t) => {
       })
       .useFallThroughTargeting({
         highTide: targetEquals(z.boolean()),
-      })
-      .build(),
+      }),
   )
     .insert({
       bar: {
@@ -436,8 +428,7 @@ Deno.test('inserting data with variables', async (t) => {
       .useTargeting({
         weather: targetIncludes(z.string()),
         highTide: targetEquals(z.boolean()),
-      })
-      .build(),
+      }),
   )
     .insert({
       bar: {
@@ -513,8 +504,7 @@ Deno.test('targeting predicate with full query object', async () => {
           predicate: (q) => (t) => q === t,
         },
         mung: mungTargeting,
-      })
-      .build(),
+      }),
   )
     .addRules('foo', [
       {
@@ -548,8 +538,7 @@ Deno.test('broken', async (t) => {
       })
       .useFallThroughTargeting({
         browser: browserTargeting,
-      })
-      .build(),
+      }),
   )
     .addRules('foo', [
       {
@@ -596,8 +585,7 @@ Deno.test('variables', async (t) => {
       })
       .useFallThroughTargeting({
         browser: targetIncludes(z.enum(['chrome', 'edge'])),
-      })
-      .build(),
+      }),
   )
     .addRules('foo', {
       variables: {
@@ -653,8 +641,7 @@ Deno.test('variables using fallthrough targeting', async (t) => {
       })
       .useFallThroughTargeting({
         browser: targetIncludes(z.enum(['chrome', 'edge'])),
-      })
-      .build(),
+      }),
   )
     .addRules('foo', {
       variables: {
@@ -698,8 +685,7 @@ Deno.test('variables in records', async () => {
     DataSchema.create()
       .usePayload({
         foo: z.record(z.string(), z.array(z.number())),
-      })
-      .build(),
+      }),
   )
     .addRules('foo', {
       variables: {
@@ -721,8 +707,7 @@ Deno.test('variables in arrays', async (t) => {
           b: z.number(),
           c: z.string(),
         })),
-      })
-      .build(),
+      }),
   ).addRules('foo', {
     variables: {
       a: [{ payload: 1 }],
@@ -763,8 +748,7 @@ Deno.test('errors when using variables with incorrect types', async (t) => {
             }),
           }),
         }),
-      })
-      .build(),
+      }),
   )
 
   await assertSnapshot(
@@ -807,11 +791,9 @@ Deno.test(
       .usePayload({ 'foo': z.string() })
     const clientConfig = basePayload
       .useTargeting({ fft: minInnerWindowWidthTargeting })
-      .build()
     const serverSchema = Data.create(
       basePayload
-        .useFallThroughTargeting(clientConfig.targetingParsers)
-        .build(),
+        .useFallThroughTargeting(clientConfig.targetingParsers),
     ).addRules('foo', {
       variables: {
         x: [{

--- a/packages/api/test/type-stress.test.ts
+++ b/packages/api/test/type-stress.test.ts
@@ -134,8 +134,7 @@ Deno.test('type stress: 100 payloads + 30 targeting descriptors', async () => {
       .useTargeting({ target_26: targetEquals(z.string()) })
       .useTargeting({ target_27: targetEquals(z.string()) })
       .useTargeting({ target_28: targetEquals(z.string()) })
-      .useTargeting({ target_29: targetEquals(z.string()) })
-      .build(),
+      .useTargeting({ target_29: targetEquals(z.string()) }),
   )
     .addRules('payload_0', [{ payload: 'hello' }])
     .addRules('payload_99', [{ payload: 'world' }])

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -47,7 +47,6 @@ export const schema = DataSchema.create()
   .useTargeting({
     country: targetIncludes(z.string()),
   })
-  .build()
 ```
 
 ### 2. Set Up the Server
@@ -169,7 +168,6 @@ export const schema = DataSchema.create()
   .useTargeting({
     device: deviceTargeting,
   })
-  .build()
 ```
 
 ```typescript

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,4 @@
-import type { Data, DT, PT, QT, QueryableData } from '@targetd/api'
+import type { Data, DataSchema, PT, QT, QueryableData } from '@targetd/api'
 import { queryToURLSearchParams } from './queryToURLSearchParams.ts'
 import { ZodError } from 'zod'
 import { ResponseError } from './ResponseError.ts'
@@ -18,7 +18,8 @@ import { ResponseError } from './ResponseError.ts'
  * const allPayloads = await client.getPayloadForEachName({ country: 'US' })
  * ```
  */
-export class Client<$ extends DT.Meta> implements QueryableData<$> {
+export class Client<$ extends DataSchema = DataSchema>
+  implements QueryableData<$> {
   #baseURL: string
 
   #data: Data<$>
@@ -67,11 +68,11 @@ export class Client<$ extends DT.Meta> implements QueryableData<$> {
    * // Returns: 'Hi!' (default fallback)
    * ```
    */
-  async getPayload<Name extends keyof $['PayloadParsers']>(
+  async getPayload<Name extends keyof $['payloadParsers']>(
     name: Name,
-    rawQuery?: QT.Raw<$['QueryParsers']>,
+    rawQuery?: QT.Raw<$['queryParsers']>,
   ): Promise<
-    | PT.Payload<$, $['PayloadParsers'][Name]>
+    | PT.Payload<$, $['payloadParsers'][Name]>
     | undefined
   > {
     const query = this.#data.QueryParser.parse(rawQuery ?? {})
@@ -122,7 +123,7 @@ export class Client<$ extends DT.Meta> implements QueryableData<$> {
    * ```
    */
   async getPayloadForEachName(
-    rawQuery?: QT.Raw<$['QueryParsers']>,
+    rawQuery?: QT.Raw<$['queryParsers']>,
   ): Promise<PT.Payloads<$>> {
     const query = this.#data.QueryParser.parse(rawQuery ?? {})
     const urlSearchParams = queryToURLSearchParams(query)
@@ -167,11 +168,11 @@ export class Client<$ extends DT.Meta> implements QueryableData<$> {
    * // Returns: ['Hello!', 'Hi!']
    * ```
    */
-  async getPayloads<Name extends keyof $['PayloadParsers']>(
+  async getPayloads<Name extends keyof $['payloadParsers']>(
     name: Name,
-    rawQuery?: QT.Raw<$['QueryParsers']>,
+    rawQuery?: QT.Raw<$['queryParsers']>,
   ): Promise<
-    PT.Payload<$, $['PayloadParsers'][Name]>[]
+    PT.Payload<$, $['payloadParsers'][Name]>[]
   > {
     const query = this.#data.QueryParser.parse(rawQuery ?? {})
     const urlSearchParams = queryToURLSearchParams(query)
@@ -208,14 +209,3 @@ export class Client<$ extends DT.Meta> implements QueryableData<$> {
     }
   }
 }
-
-/**
- * Helper type to create a Client from a Data instance type.
- *
- * @example
- * ```ts
- * const data = await Data.create(DataSchema.create()...build())
- * type MyClient = ClientWithData<typeof data>
- * ```
- */
-export type ClientWithData<D extends DT.Any> = Client<DT.$<D>>

--- a/packages/client/test/index.test.ts
+++ b/packages/client/test/index.test.ts
@@ -6,7 +6,7 @@ import { createServer } from '@targetd/server'
 import type { AddressInfo } from 'node:net'
 import { setTimeout } from 'node:timers/promises'
 import z from 'zod'
-import { Client, type ClientWithData } from '@targetd/client'
+import { Client } from '@targetd/client'
 import { promisify } from 'node:util'
 
 const data = await Data.create(
@@ -26,8 +26,7 @@ const data = await Data.create(
         targetingParser: z.boolean(),
       },
       date: dateRangeTargeting,
-    })
-    .build(),
+    }),
 )
   .addRules('foo', [
     {
@@ -142,7 +141,7 @@ Deno.test('get all matching payloads', async (t) => {
 })
 
 async function startService(): Promise<
-  AsyncDisposable & { client: ClientWithData<typeof data> }
+  AsyncDisposable & { client: Client<typeof data['schema']> }
 > {
   const app = createServer(data)
   const { promise, reject, resolve } = Promise.withResolvers<void>()

--- a/packages/date-range/README.md
+++ b/packages/date-range/README.md
@@ -41,7 +41,6 @@ const schema = DataSchema.create()
   .useTargeting({
     dateRange: dateRangeTargeting,
   })
-  .build()
 
 const data = await Data.create(schema).addRules('banner', [
   {
@@ -211,7 +210,6 @@ const schema = DataSchema.create()
   .useTargeting({
     dateRange: dateRangeTargeting,
   })
-  .build()
 
 const data = await Data.create(schema).addRules('event', [
   {

--- a/packages/date-range/src/index.ts
+++ b/packages/date-range/src/index.ts
@@ -60,8 +60,7 @@ const targetingParser: TargetingParser = union([
  * const data = await Data.create(
  *   DataSchema.create()
  *     .usePayload({ campaign: z.string() })
- *     .useTargeting({ date: dateRangeTargeting })
- *     .build(),
+ *     .useTargeting({ date: dateRangeTargeting }),
  * ).addRules('campaign', [
  *   {
  *     targeting: {

--- a/packages/date-range/test/index.test.ts
+++ b/packages/date-range/test/index.test.ts
@@ -12,8 +12,7 @@ Deno.test('date range predicate', async () => {
       })
       .useTargeting({
         dateRange: dateRangeTargeting,
-      })
-      .build(),
+      }),
   )
     .addRules('foo', [
       {

--- a/packages/explode/README.md
+++ b/packages/explode/README.md
@@ -39,8 +39,7 @@ const data = await Data.create(
       'app.title': z.string(),
       'app.version': z.string(),
       'feature.darkMode': z.boolean(),
-    })
-    .build(),
+    }),
 )
   .addRules('app.title', [{ payload: 'My App' }])
   .addRules('app.version', [{ payload: '1.0.0' }])
@@ -96,8 +95,7 @@ const data = await Data.create(
       'api.timeout': z.number(),
       'ui.theme': z.string(),
       'ui.language': z.string(),
-    })
-    .build(),
+    }),
 )
   .addRules('api.endpoint', [{ payload: 'https://api.example.com' }])
   .addRules('api.timeout', [{ payload: 5000 }])
@@ -136,7 +134,6 @@ const schema = DataSchema.create()
   .useTargeting({
     platform: targetIncludes(z.string()),
   })
-  .build()
 
 const data = await Data.create(schema)
   .addRules('feature.mobile.enabled', [

--- a/packages/explode/src/types.ts
+++ b/packages/explode/src/types.ts
@@ -1,4 +1,4 @@
-import type { DT, PT } from '@targetd/api'
+import type { DataSchema, PT } from '@targetd/api'
 import type { O, S, U } from 'ts-toolbelt'
 
 /**
@@ -19,13 +19,13 @@ import type { O, S, U } from 'ts-toolbelt'
  * ```
  */
 export type ExplodedPayloads<
-  D extends DT.Any,
+  $ extends DataSchema,
   PathSeparator extends string,
 > = Explode<
   Partial<
     {
-      [Name in keyof DT.PayloadParsers<D>]:
-        | PT.Payload<DT.PayloadParsers<D>[Name], DT.TargetingParsers<D>>
+      [Name in keyof $['payloadParsers']]:
+        | PT.Payload<$, $['payloadParsers'][Name]>
         | undefined
     }
   >,

--- a/packages/fs/README.md
+++ b/packages/fs/README.md
@@ -92,8 +92,7 @@ const data = await Data.create(
     })
     .useTargeting({
       country: targetIncludes(z.string()),
-    })
-    .build(),
+    }),
 )
 
 // Load rules from directory
@@ -119,8 +118,7 @@ const data = await Data.create(
     })
     .useTargeting({
       country: targetIncludes(z.string()),
-    })
-    .build(),
+    }),
 )
 
 // Watch directory and reload on changes
@@ -204,8 +202,7 @@ const data = await Data.create(
     })
     .useTargeting({
       environment: targetIncludes(z.string()),
-    })
-    .build(),
+    }),
 )
 
 // Load rules from filesystem
@@ -268,8 +265,7 @@ const data = await Data.create(
     })
     .useTargeting({
       environment: targetIncludes(z.string()),
-    })
-    .build(),
+    }),
 )
 
 // Watch for changes during development
@@ -329,8 +325,7 @@ const data = await Data.create(
     .useTargeting({
       country: targetIncludes(z.string()),
       tier: targetIncludes(z.string()),
-    })
-    .build(),
+    }),
 )
 
 const dataWithRules = await load(data, './rules')

--- a/packages/fs/src/load.ts
+++ b/packages/fs/src/load.ts
@@ -1,8 +1,8 @@
 import fs from '@johngw/fs'
 import type { WithFileNamesResult } from '@johngw/fs/dist/readFiles'
-import type { DT } from '@targetd/api'
 import { object } from 'zod'
 import { any, type output } from 'zod/mini'
+import type { Data, DataSchema } from '@targetd/api'
 
 /**
  * Zod schema for validating file data structure.
@@ -32,8 +32,7 @@ type FileData = output<typeof FileData>
  * const baseData = await Data.create(
  *   DataSchema.create()
  *     .usePayload({ greeting: z.string() })
- *     .useTargeting({ country: targetIncludes(z.string()) })
- *     .build(),
+ *     .useTargeting({ country: targetIncludes(z.string()) }),
  * )
  *
  * const data = await load(baseData, './rules')
@@ -50,7 +49,10 @@ type FileData = output<typeof FileData>
  *     - payload: Hi!
  * ```
  */
-export async function load<D extends DT.Any>(data: D, dir: string): Promise<D> {
+export async function load<$ extends DataSchema>(
+  data: Data<$>,
+  dir: string,
+): Promise<Data<$>> {
   for await (
     const contents of fs.readFiles(dir, {
       encoding: 'utf8',
@@ -104,15 +106,15 @@ async function parseFileContents({
  * @param fileData - Parsed file data containing rules
  * @returns Updated Data instance with added rules
  */
-async function addRules<D extends DT.Any>(
-  data: D,
+async function addRules<$ extends DataSchema>(
+  data: Data<$>,
   fileData: FileData,
-): Promise<D> {
+): Promise<Data<$>> {
   let result = data
 
   for (const [key, value] of Object.entries(fileData)) {
     if (typeof value === 'object') {
-      result = (await result.addRules(key, value)) as D
+      result = await result.addRules(key, value)
     }
   }
 

--- a/packages/fs/src/watch.ts
+++ b/packages/fs/src/watch.ts
@@ -1,10 +1,10 @@
-import type { DT } from '@targetd/api'
 import { debounce, Mutex } from '@es-toolkit/es-toolkit'
 import {
   watch as fsWatch,
   type WatchOptions as BaseWatchOptions,
 } from 'node:fs'
 import { load, pathIsLoadable } from './load.ts'
+import type { Data, DataSchema } from '@targetd/api'
 
 /**
  * Callback function invoked when rules are loaded or reloaded by the watch function.
@@ -27,7 +27,10 @@ import { load, pathIsLoadable } from './load.ts'
  * }
  * ```
  */
-export type OnLoad<D extends DT.Any> = (error: Error | null, data: D) => any
+export type OnLoad<$ extends DataSchema> = (
+  error: Error | null,
+  data: Data<$>,
+) => any
 
 /**
  * Options for watching a directory for rule file changes.
@@ -59,8 +62,7 @@ export interface WatchOptions extends BaseWatchOptions {
  * const baseData = await Data.create(
  *   DataSchema.create()
  *     .usePayload({ greeting: z.string() })
- *     .useTargeting({ country: targetIncludes(z.string()) })
- *     .build(),
+ *     .useTargeting({ country: targetIncludes(z.string()) }),
  * )
  *
  * let currentData = baseData
@@ -78,36 +80,36 @@ export interface WatchOptions extends BaseWatchOptions {
  * stopWatching()
  * ```
  */
-export function watch<D extends DT.Any>(
-  data: D,
+export function watch<$ extends DataSchema>(
+  data: Data<$>,
   dir: string,
   options: WatchOptions,
-  onLoad: OnLoad<D>,
+  onLoad: OnLoad<$>,
 ): WatchDisposer
 
-export function watch<D extends DT.Any>(
-  data: D,
+export function watch<$ extends DataSchema>(
+  data: Data<$>,
   dir: string,
-  onLoad: OnLoad<D>,
+  onLoad: OnLoad<$>,
 ): WatchDisposer
 
-export function watch<D extends DT.Any>(
-  data: D,
+export function watch<$ extends DataSchema>(
+  data: Data<$>,
   dir: string,
-  optionsOrOnLoad: WatchOptions | OnLoad<D>,
-  onLoadParam?: OnLoad<D>,
+  optionsOrOnLoad: WatchOptions | OnLoad<$>,
+  onLoadParam?: OnLoad<$>,
 ) {
   const { debounceMS = 300, ...fsOptions } = onLoadParam
     ? optionsOrOnLoad as WatchOptions
     : {}
-  const onLoad = (onLoadParam || optionsOrOnLoad) as OnLoad<D>
+  const onLoad = (onLoadParam || optionsOrOnLoad) as OnLoad<$>
   const mutex = new Mutex()
 
   const onChange = async () => {
     await mutex.acquire()
     let error: Error | null = null
     try {
-      data = await load(data.removeAllRules(), dir) as D
+      data = await load(data.removeAllRules(), dir)
     } catch ($error: any) {
       error = $error
     } finally {

--- a/packages/fs/test/fixtures/data.ts
+++ b/packages/fs/test/fixtures/data.ts
@@ -7,6 +7,5 @@ export const data = await Data.create(
       foo: z.string(),
       b: z.string(),
     })
-    .useTargeting({ channel: targetIncludes(string()) })
-    .build(),
+    .useTargeting({ channel: targetIncludes(string()) }),
 )

--- a/packages/json-schema/src/cli.ts
+++ b/packages/json-schema/src/cli.ts
@@ -1,10 +1,10 @@
-import type { DT } from '@targetd/api'
 import yargs from 'yargs'
 import * as path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { writeFile } from 'node:fs/promises'
 import { argv, cwd } from 'node:process'
 import { dataJSONSchemas } from './index.ts'
+import type { Data } from '@targetd/api'
 
 const { dataExport, inputModule, outputFile } = await yargs()
   .usage('targetd-json-schema [args]')
@@ -47,6 +47,6 @@ const jsonSchema = JSON.stringify(dataJSONSchemas(data), null, 2)
 if (outputFile) await writeFile(outputFile, jsonSchema)
 else console.info(jsonSchema)
 
-function isDataLike(x: any): x is DT.Any {
+function isDataLike(x: any): x is Data {
   return 'payloadParsers' in x && 'targetingParsers' in x
 }

--- a/packages/json-schema/src/cli.ts
+++ b/packages/json-schema/src/cli.ts
@@ -47,6 +47,7 @@ const jsonSchema = JSON.stringify(dataJSONSchemas(data), null, 2)
 if (outputFile) await writeFile(outputFile, jsonSchema)
 else console.info(jsonSchema)
 
-function isDataLike(x: any): x is Data {
-  return 'payloadParsers' in x && 'targetingParsers' in x
+function isDataLike(x: unknown): x is Data {
+  return typeof x === 'object' && x !== null && 'payloadParsers' in x &&
+    'targetingParsers' in x
 }

--- a/packages/json-schema/src/index.ts
+++ b/packages/json-schema/src/index.ts
@@ -1,8 +1,9 @@
 import { omit } from '@es-toolkit/es-toolkit'
 import {
+  type Data,
   DataItemParser,
   DataItemsParser,
-  type DT,
+  type DataSchema,
   isZodSwitch,
 } from '@targetd/api'
 import { extend, optional, string, toJSONSchema } from 'zod/mini'
@@ -24,8 +25,8 @@ import type { JSONSchema } from 'zod/v4/core'
  * await Deno.writeTextFile('schema.json', JSON.stringify(schema, null, 2))
  * ```
  */
-export function dataJSONSchemas<D extends DT.Any>(
-  data: D,
+export function dataJSONSchemas<$ extends DataSchema>(
+  data: Data<$>,
   params?: ToJSONSchemaParams,
 ): JSONSchema.BaseSchema {
   return toJSONSchema(
@@ -34,7 +35,7 @@ export function dataJSONSchemas<D extends DT.Any>(
         data.payloadParsers,
         data.targetingParsers,
         data.fallThroughTargetingParsers,
-      ) as any,
+      ),
       { $schema: optional(string()) },
     ),
     toJSONSchemaParams(params),
@@ -56,9 +57,9 @@ export function dataJSONSchemas<D extends DT.Any>(
  * console.log(greetingSchema)
  * ```
  */
-export function dataJSONSchema<D extends DT.Any>(
-  data: D,
-  name: keyof DT.PayloadParsers<D>,
+export function dataJSONSchema<$ extends DataSchema>(
+  data: Data<$>,
+  name: keyof $['payloadParsers'],
   params?: ToJSONSchemaParams,
 ): JSONSchema.BaseSchema {
   return toJSONSchema(
@@ -68,7 +69,7 @@ export function dataJSONSchema<D extends DT.Any>(
         data.targetingParsers,
         data.fallThroughTargetingParsers,
         true,
-      ) as any,
+      ),
       { $schema: optional(string()) },
     ),
     toJSONSchemaParams(params),

--- a/packages/json-schema/test/fixtures/data.ts
+++ b/packages/json-schema/test/fixtures/data.ts
@@ -19,8 +19,7 @@ export const data = await Data.create(
     })
     .useFallThroughTargeting({
       browser: targetIncludes(z.string()),
-    })
-    .build(),
+    }),
 )
   .addRules('foo', {
     variables: {

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -44,7 +44,6 @@ const schema = DataSchema.create()
   .useTargeting({
     country: targetIncludes(z.string()),
   })
-  .build()
 
 const data = await Data.create(schema)
   .addRules('greeting', [
@@ -179,7 +178,6 @@ const schema = DataSchema.create()
     platform: targetIncludes(z.string()),
     isPremium: targetEquals(z.boolean()),
   })
-  .build()
 
 const data = await Data.create(schema)
   .addRules('banner', [
@@ -235,8 +233,7 @@ import { createServer } from '@targetd/server'
 
 const baseData = await Data.create(
   DataSchema.create()
-    .usePayload({ content: z.string() })
-    .build(),
+    .usePayload({ content: z.string() }),
 )
 
 let currentData = baseData
@@ -271,7 +268,6 @@ const schema = DataSchema.create()
     region: targetIncludes(z.string()),
     language: targetIncludes(z.string()),
   })
-  .build()
 
 const data = await Data.create(schema).addRules('content', [
   {
@@ -330,8 +326,7 @@ app.get('/health', (req, res) => {
 // Add targetd endpoints
 const data = await Data.create(
   DataSchema.create()
-    .usePayload({ config: z.object({ version: z.string() }) })
-    .build(),
+    .usePayload({ config: z.object({ version: z.string() }) }),
 ).addRules('config', [{ payload: { version: '1.0.0' } }])
 
 createServer(data, { app })
@@ -359,7 +354,6 @@ const schema = DataSchema.create()
   .useTargeting({
     date: dateRangeTargeting,
   })
-  .build()
 
 const data = await Data.create(schema).addRules('campaign', [
   {
@@ -405,7 +399,6 @@ const schema = DataSchema.create()
   .useTargeting({
     interests: targetIncludes(z.string()),
   })
-  .build()
 
 const data = await Data.create(schema).addRules('recommendations', [
   {
@@ -519,7 +512,6 @@ import { createServer } from '@targetd/server'
 const schema = DataSchema.create()
   .usePayload({ greeting: z.string() })
   .useTargeting({ country: targetIncludes(z.string()) })
-  .build()
 
 export const data = await Data.create(schema).addRules('greeting', [
   { targeting: { country: ['US'] }, payload: 'Hello!' },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,4 @@
-import type { DT } from '@targetd/api'
+import type { Data, DataSchema, QT } from '@targetd/api'
 import cors from 'cors'
 import express from 'express'
 import { errorHandler } from './middleware/error.ts'
@@ -11,7 +11,7 @@ import type { MaybePromise } from './types.ts'
  * Configuration options for createServer.
  */
 export interface CreateServerOptions<
-  D extends DT.Any = DT.Any,
+  $ extends DataSchema = DataSchema,
   App extends express.Express = express.Express,
 > {
   /**
@@ -28,7 +28,7 @@ export interface CreateServerOptions<
    * // GET /US/en is equivalent to /?region=US&language=en
    * ```
    */
-  pathStructure?: (keyof DT.QueryParsers<D>)[]
+  pathStructure?: (keyof $['queryParsers'])[]
 }
 
 /**
@@ -50,8 +50,7 @@ export interface CreateServerOptions<
  * const data = await Data.create(
  *   DataSchema.create()
  *     .usePayload({ greeting: z.string() })
- *     .useTargeting({ country: targetIncludes(z.string()) })
- *     .build(),
+ *     .useTargeting({ country: targetIncludes(z.string()) }),
  * ).addRules('greeting', [
  *   { targeting: { country: ['US'] }, payload: 'Hello!' },
  *   { payload: 'Hi!' }
@@ -81,14 +80,14 @@ export interface CreateServerOptions<
  * ```
  */
 export function createServer<
-  D extends DT.Any,
+  $ extends DataSchema,
   App extends express.Express = express.Express,
 >(
-  data: MaybePromise<D> | (() => MaybePromise<D>),
+  data: MaybePromise<Data<$>> | (() => MaybePromise<Data<$>>),
   {
     app = express() as App,
     pathStructure,
-  }: CreateServerOptions<D, App> = {},
+  }: CreateServerOptions<$, App> = {},
 ): App {
   const getData = typeof data === 'function' ? data : () => data
 
@@ -101,10 +100,12 @@ export function createServer<
       castQueryArrayProps(getData),
       async (req, res) => {
         res.json(
-          await (await getData()).getPayloadForEachName({
-            ...req.params,
-            ...(res.locals.query ?? req.query),
-          }),
+          await (await getData()).getPayloadForEachName(
+            {
+              ...req.params,
+              ...(res.locals.query ?? req.query),
+            } as QT.Raw<$['queryParsers']>,
+          ),
         )
       },
     )
@@ -116,7 +117,9 @@ export function createServer<
       castQueryProp(),
       castQueryArrayProps(getData),
       async (req, res) => {
-        const query = res.locals.query ?? req.query
+        const query = (res.locals.query ?? req.query) as QT.Raw<
+          $['queryParsers']
+        >
         const data = await getData()
 
         if (!(req.params.name in data.payloadParsers)) {
@@ -131,7 +134,9 @@ export function createServer<
       castQueryProp(),
       castQueryArrayProps(getData),
       async (req, res) => {
-        const query = res.locals.query ?? req.query
+        const query = (res.locals.query ?? req.query) as QT.Raw<
+          $['queryParsers']
+        >
         const data = await getData()
 
         if (!(req.params.name in data.payloadParsers)) {
@@ -151,7 +156,7 @@ export function createServer<
       async (req, res) => {
         res.json(
           await (await getData()).getPayloadForEachName(
-            res.locals.query ?? req.query,
+            (res.locals.query ?? req.query) as QT.Raw<$['queryParsers']>,
           ),
         )
       },

--- a/packages/server/src/middleware/castQueryArrayProps.ts
+++ b/packages/server/src/middleware/castQueryArrayProps.ts
@@ -1,4 +1,4 @@
-import type { DT } from '@targetd/api'
+import type { Data, DataSchema } from '@targetd/api'
 import type { RequestHandler } from 'express'
 import type { MaybePromise } from '../types.ts'
 import type { ParsedQs } from './castQueryProp.ts'
@@ -13,13 +13,14 @@ import type { ParsedQs } from './castQueryProp.ts'
  * @internal
  */
 export function castQueryArrayProps<
+  $ extends DataSchema,
   P extends Record<string, string>,
   ResBody,
   ReqBody,
   ReqQuery,
   Locals extends { query: ParsedQs },
 >(
-  getData: () => MaybePromise<DT.Any>,
+  getData: () => MaybePromise<Data<$>>,
 ): RequestHandler<P, ResBody, ReqBody, ReqQuery, Locals> {
   return async (_req, res, next) => {
     const { queryParsers } = await getData()

--- a/packages/server/test/index.test.ts
+++ b/packages/server/test/index.test.ts
@@ -1,11 +1,5 @@
 import { assertSnapshot } from 'jsr:@std/testing/snapshot'
-import {
-  Data,
-  DataSchema,
-  type DT,
-  targetEquals,
-  targetIncludes,
-} from '@targetd/api'
+import { Data, DataSchema, targetEquals, targetIncludes } from '@targetd/api'
 import dateRangeTargeting from '@targetd/date-range'
 import _ from 'npm:lodash'
 import { setTimeout } from 'node:timers/promises'
@@ -126,7 +120,7 @@ Deno.test('get all', async (t) => {
 })
 
 async function createDisposableServer(options?: {
-  data?: DT.Any
+  data?: Data
   pathStructure?: string[]
 }): Promise<Server & AsyncDisposable> {
   const data = options?.data ?? createData()
@@ -163,8 +157,7 @@ function createData() {
           targetingParser: z.string().array(),
         },
         date: dateRangeTargeting,
-      })
-      .build(),
+      }),
   )
     .addRules('foo', [
       {
@@ -242,8 +235,7 @@ Deno.test('custom path structure', async () => {
       .useTargeting({
         region: targetIncludes(z.string()),
         device: targetIncludes(z.string()),
-      })
-      .build(),
+      }),
   )
     .addRules('content', [
       {


### PR DESCRIPTION
DataSchema now exposes its parser records as public readonly fields and is passed directly to `Data.create()` — the separate `.build()` step and the `BuiltDataSchema` interface are gone. The DT.Meta indirection is also removed: `Data<$ extends DataSchema = DataSchema>` indexes the schema directly using camelCase keys that mirror the runtime object (`$['payloadParsers']`, etc.), so there is one shape for both type-level and value-level access.

TargetingPredicates is decoupled from the old Meta shape, `Data` exposes a `schema` getter, and downstream packages (server, client, fs, explode, json-schema, date-range) are updated to the new generic.

BREAKING CHANGE: `.build()`, `BuiltDataSchema`, `DT.Meta`, and `DT.EmptyMeta` have been removed.

Migration:
- Drop `.build()` calls; pass the `DataSchema` to `Data.create()` directly.
- Replace `$ extends DT.Meta` with `$ extends DataSchema`.
- Rename indexed access keys from PascalCase to camelCase: `$['PayloadParsers']`              → `$['payloadParsers']` `$['TargetingParsers']`            → `$['targetingParsers']` `$['QueryParsers']`                → `$['queryParsers']` `$['FallThroughTargetingParsers']` → `$['fallThroughTargetingParsers']`
- Replace `DT.Any` with `DataSchema` in generic constraints where you previously used it as the "match any" bound.